### PR TITLE
Resolve 31 - NRE when analyzing project IDs

### DIFF
--- a/src/Incrementalist/ProjectSystem/Cmds/ComputeDependencyGraphCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/ComputeDependencyGraphCmd.cs
@@ -37,7 +37,12 @@ namespace Incrementalist.ProjectSystem.Cmds
 
             var ds = _solution.GetProjectDependencyGraph();
 
-            // NOTE: what happens if the SLN file is modified? Return everything?
+            // Special case: if the solution itself is modified, return all projects
+            if (affectedSlnFiles.ContainsKey(_solution.FilePath))
+            {
+                return _solution.Projects.Select(x => x.FilePath);
+            }
+
             var uniqueProjectIds = affectedSlnFiles.Select(x => x.Value.ProjectId).Distinct().ToList();
             var graphs = uniqueProjectIds.ToDictionary(x => x,
                 v => ds.GetProjectsThatTransitivelyDependOnThisProject(v).ToList());


### PR DESCRIPTION
close #31 - occurred when .SLN file itself was modified