### PR TITLE
v0.1.2 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,6 @@
-#### 0.1.1 May 08 2019 ####
-Bugfix release for Incrementalist v0.1.0.
+#### 0.1.2 May 08 2019 ####
+Bugfix release for Incrementalist v0.1.1.
 
 Addresses the following issues:
 
-1. [Error: head projectId cannot be null](https://github.com/petabridge/Incrementalist/issues/31)
-2. [Bug: System.ArgumentException: An item with the same key has already been added.](https://github.com/petabridge/Incrementalist/issues/27)
-3. [Need to validate that the Head branch exists](https://github.com/petabridge/Incrementalist/issues/28)
+1. [Workaround CI mangling of Git branches](https://github.com/petabridge/Incrementalist/pull/39)

--- a/build.fsx
+++ b/build.fsx
@@ -115,6 +115,29 @@ Target "RunTests" (fun _ ->
     projects |> Seq.iter (runSingleProject)
 )
 
+Target "IntegrationTests" <| fun _ ->    
+    let integrationTests = !! "./src/**/Incrementalist.Cmd.csproj"
+
+    let runSingleProject project =
+        
+        let folderOnlyArgs = sprintf "run --project %s -c %s --no-build -- -b dev -l" project configuration
+        let slnArgs = sprintf "run --project %s -c %s --no-build -- -b dev" project configuration
+
+        let execWithArgs args =
+            let result = ExecProcess(fun info ->
+                info.FileName <- "dotnet"
+                info.WorkingDirectory <- __SOURCE_DIRECTORY__
+                info.Arguments <- args) (TimeSpan.FromMinutes 5.0) 
+            if result <> 0 then failwithf "Incrementalist failed.%s" args
+        
+        log "Running Incrementalist folders-only check"
+        execWithArgs folderOnlyArgs
+
+        log "Running Incrementalist solution check"
+        execWithArgs slnArgs
+
+    integrationTests |> Seq.iter runSingleProject
+
 Target "NBench" <| fun _ ->
     let projects = 
         match (isWindows) with 
@@ -311,6 +334,7 @@ Target "Nuget" DoNothing
 
 // all
 "BuildRelease" ==> "All"
+"IntegrationTests" ==> "All"
 "RunTests" ==> "All"
 "NBench" ==> "All"
 "Nuget" ==> "All"

--- a/src/Incrementalist.Cmd/Program.cs
+++ b/src/Incrementalist.Cmd/Program.cs
@@ -95,10 +95,20 @@ namespace Incrementalist.Cmd
                 // validate the target branch
                 if (!DiffHelper.HasBranch(repoResult.repo, options.GitBranch))
                 {
-                    Console.WriteLine("Current git repository doesn't have any branch named [{0}]. Shutting down.", options.GitBranch);
-                    return -4;
+                    // workaround common CI server issues and check to see if this same branch is located
+                    // under "origin/{branchname}"
+                    options.GitBranch = $"origin/{options.GitBranch}";
+                    if (!DiffHelper.HasBranch(repoResult.repo, options.GitBranch))
+                    {
+                        Console.WriteLine("Current git repository doesn't have any branch named [{0}]. Shutting down.", options.GitBranch);
+                        Console.WriteLine("[Debug] Here are all of the currently known branches in this repository");
+                        foreach (var b in repoResult.repo.Branches)
+                        {
+                            Console.WriteLine(b.FriendlyName);
+                        }
+                        return -4;
+                    }
                 }
-
 
                 if (!string.IsNullOrEmpty(repoFolder))
                 {

--- a/src/common.props
+++ b/src/common.props
@@ -2,12 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.1</VersionPrefix>
-    <PackageReleaseNotes>Bugfix release for Incrementalist v0.1.0.
+    <VersionPrefix>0.1.2</VersionPrefix>
+    <PackageReleaseNotes>Bugfix release for Incrementalist v0.1.1.
 Addresses the following issues:
-1. [Error: head projectId cannot be null](https://github.com/petabridge/Incrementalist/issues/31)
-2. [Bug: System.ArgumentException: An item with the same key has already been added.](https://github.com/petabridge/Incrementalist/issues/27)
-3. [Need to validate that the Head branch exists](https://github.com/petabridge/Incrementalist/issues/28)</PackageReleaseNotes>
+1. [Workaround CI mangling of Git branches](https://github.com/petabridge/Incrementalist/pull/39)</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIconUrl>
       https://petabridge.com/images/logo.png


### PR DESCRIPTION
#### 0.1.2 May 08 2019 ####
Bugfix release for Incrementalist v0.1.1.

Addresses the following issues:

1. [Workaround CI mangling of Git branches](https://github.com/petabridge/Incrementalist/pull/39)