### PR TITLE
v0.1.4 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,17 @@
-#### 0.1.3 May 15 2019 ####
-Bugfix release for Incrementalist v0.1.2.
+#### 0.1.4 May 17 2019 ####
+Bugfix release for Incrementalist v0.1.3
 
-Added more verbose logging when no changes are detected.
+Fixed [MSBuild graph issue where two unrelated changes in the same branch could overwrite each other in the Incrementalist output](https://github.com/petabridge/Incrementalist/issues/49).
+
+In the event of three concurrent MSBuild dependency graphs like these:
+
+[A modified] Project A --> B --> C
+[B modified] Project B --> C
+[D modified] Project D --> E
+
+In Incrementalist 0.1.3, you'd only see this graph: `Project A --> B --> C` because it was the longest and "covered" all of the other graphs. In Incrementalist 0.1.4 you'll now see the following build output:
+
+Project A --> B --> C
+Project D --> E
+
+Each line represents its own independent graph, uncovered by any of the other graphs detected in the topology of the MSBuild solution.

--- a/src/Incrementalist.Cmd/Commands/EmitAffectedFoldersTask.cs
+++ b/src/Incrementalist.Cmd/Commands/EmitAffectedFoldersTask.cs
@@ -31,7 +31,7 @@ namespace Incrementalist.Cmd.Commands
 
         public ILogger Logger { get; }
 
-        public async Task<IEnumerable<string>> Run()
+        public async Task<Dictionary<string, ICollection<string>>> Run()
         {
             // load the git repository
             var repoResult = GitRunner.FindRepository(Settings.WorkingDirectory);
@@ -39,14 +39,14 @@ namespace Incrementalist.Cmd.Commands
             if (!repoResult.foundRepo)
             {
                 Logger.LogError("Unable to find Git repository located in {0}. Shutting down.", Settings.WorkingDirectory);
-                return new List<string>();
+                return new Dictionary<string, ICollection<string>>();
             }
 
             // validate the target branch
             if (!DiffHelper.HasBranch(repoResult.repo, Settings.TargetBranch))
             {
                 Logger.LogError("Current git repository doesn't have any branch named [{0}]. Shutting down.", Settings.TargetBranch);
-                return new List<string>();
+                return new Dictionary<string, ICollection<string>>();
             }
 
             // start the cancellation timer.

--- a/src/Incrementalist.Cmd/Commands/EmitDependencyGraphTask.cs
+++ b/src/Incrementalist.Cmd/Commands/EmitDependencyGraphTask.cs
@@ -37,7 +37,7 @@ namespace Incrementalist.Cmd.Commands
 
         public ILogger Logger { get; }
 
-        public async Task<IEnumerable<string>> Run()
+        public async Task<Dictionary<string, ICollection<string>>> Run()
         {
             // start the cancellation timer.
             _cts.CancelAfter(Settings.TimeoutDuration);

--- a/src/Incrementalist.Cmd/Program.cs
+++ b/src/Incrementalist.Cmd/Program.cs
@@ -132,9 +132,9 @@ namespace Incrementalist.Cmd
         {
             var settings = new BuildSettings(options.GitBranch, options.SolutionFilePath, workingFolder.FullName);
             var emitTask = new EmitAffectedFoldersTask(settings, logger);
-            var affectedFiles = (await emitTask.Run()).ToList();
+            var affectedFiles = (await emitTask.Run());
 
-            var affectedFilesStr = string.Join(",", affectedFiles);
+            var affectedFilesStr = string.Join(",", affectedFiles.Keys);
 
             HandleAffectedFiles(options, affectedFilesStr, affectedFiles.Count);
         }
@@ -159,7 +159,8 @@ namespace Incrementalist.Cmd
             var emitTask = new EmitDependencyGraphTask(settings, msBuild, logger);
             var affectedFiles = (await emitTask.Run()).ToList();
 
-            var affectedFilesStr = string.Join(",", affectedFiles);
+            var affectedFilesStr =
+                string.Join(Environment.NewLine, affectedFiles.Select(x => string.Join(",", x.Value)));
 
             HandleAffectedFiles(options, affectedFilesStr, affectedFiles.Count);
         }

--- a/src/Incrementalist/Git/Cmds/FilterAffectedFoldersCmd.cs
+++ b/src/Incrementalist/Git/Cmds/FilterAffectedFoldersCmd.cs
@@ -16,18 +16,19 @@ namespace Incrementalist.Git.Cmds
     /// <summary>
     ///     Filters all of the unique folders that contain affected files
     /// </summary>
-    public sealed class FilterAffectedFoldersCmd : BuildCommandBase<IEnumerable<string>, IEnumerable<string>>
+    public sealed class FilterAffectedFoldersCmd : BuildCommandBase<IEnumerable<string>, Dictionary<string, ICollection<string>>>
     {
         public FilterAffectedFoldersCmd(ILogger logger, CancellationToken cancellationToken) : base(
             "FilterAffectedFiles", logger, cancellationToken)
         {
         }
 
-        protected override async Task<IEnumerable<string>> ProcessImpl(Task<IEnumerable<string>> previousTask)
+        protected override async Task<Dictionary<string, ICollection<string>>> ProcessImpl(Task<IEnumerable<string>> previousTask)
         {
             var affectedFiles = await previousTask;
 
-            return affectedFiles.Select(Path.GetDirectoryName).Distinct();
+            return affectedFiles.GroupBy(x => Path.GetDirectoryName(x))
+                .ToDictionary(x => x.Key, grouping => (ICollection<string>)grouping.Distinct().ToList());
         }
     }
 }

--- a/src/Incrementalist/ProjectSystem/Cmds/ComputeDependencyGraphCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/ComputeDependencyGraphCmd.cs
@@ -17,7 +17,7 @@ namespace Incrementalist.ProjectSystem.Cmds
     ///     Computes the longest dependency graph from all of the affected files
     ///     and emits a topologically sorted set of project file names to be used during testing.
     /// </summary>
-    public sealed class ComputeDependencyGraphCmd : BuildCommandBase<Dictionary<string, SlnFile>, IEnumerable<string>>
+    public sealed class ComputeDependencyGraphCmd : BuildCommandBase<Dictionary<string, SlnFile>, Dictionary<string, ICollection<string>>>
     {
         private readonly Solution _solution;
 
@@ -27,32 +27,61 @@ namespace Incrementalist.ProjectSystem.Cmds
             _solution = solution;
         }
 
-        protected override async Task<IEnumerable<string>> ProcessImpl(Task<Dictionary<string, SlnFile>> previousTask)
+        protected override async Task<Dictionary<string, ICollection<string>>> ProcessImpl(Task<Dictionary<string, SlnFile>> previousTask)
         {
             var affectedSlnFiles = await previousTask;
 
             // bail out early if we don't have any affected projects
             if (affectedSlnFiles.Count == 0)
-                return new List<string>();
+                return new Dictionary<string, ICollection<string>>();
 
             var ds = _solution.GetProjectDependencyGraph();
 
             // Special case: if the solution itself is modified, return all projects
             if (affectedSlnFiles.ContainsKey(_solution.FilePath))
             {
-                return _solution.Projects.Select(x => x.FilePath);
+                return new Dictionary<string, ICollection<string>>(){ {_solution.FilePath, _solution.Projects.Select(x => x.FilePath).ToList() } };
+            }
+
+            string GetProjectFilePath(ProjectId project)
+            {
+                return _solution.GetProject(project).FilePath;
             }
 
             var uniqueProjectIds = affectedSlnFiles.Select(x => x.Value.ProjectId).Distinct().ToList();
             var graphs = uniqueProjectIds.ToDictionary(x => x,
                 v => ds.GetProjectsThatTransitivelyDependOnThisProject(v).ToList());
 
-            var longestGraph = graphs.OrderByDescending(x => x.Value.Count).FirstOrDefault();
+            /*
+             * Next: check to see if there any overlapping graphs and remove those from the final set
+             */
+            bool IsGraphContained(ProjectId root, Dictionary<ProjectId, List<ProjectId>> otherGraphs)
+            {
+                return otherGraphs.Where(x => !x.Key.Equals(root))
+                    .Any(nonRootGraph => nonRootGraph.Value.Contains(root));
+            }
 
-            var results = new HashSet<string> {_solution.GetProject(longestGraph.Key).FilePath};
-            foreach (var p in longestGraph.Value) results.Add(_solution.GetProject(p).FilePath);
+            ICollection<string> PrepareProjectPaths(ProjectId root, ICollection<ProjectId> graph)
+            {
+                var results = new HashSet<string> { _solution.GetProject(root).FilePath };
+                foreach (var p in graph)
+                {
+                    results.Add(GetProjectFilePath(p));
+                }
 
-            return results;
+                return results;
+            }
+
+            var independentGraphs = graphs.Where(x => !IsGraphContained(x.Key, graphs));
+
+            // idempotently filter out duplicates - same projectID can show up multiple times for a multi-target build
+            var finalResultSet = new Dictionary<string, ICollection<string>>();
+            foreach (var r in independentGraphs)
+            {
+                finalResultSet[GetProjectFilePath(r.Key)] = PrepareProjectPaths(r.Key, r.Value);
+            }                
+
+            return finalResultSet;
         }
     }
 }

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,17 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.1.3</VersionPrefix>
-    <PackageReleaseNotes>Bugfix release for Incrementalist v0.1.2.
-Added more verbose logging when no changes are detected.</PackageReleaseNotes>
+    <VersionPrefix>0.1.4</VersionPrefix>
+    <PackageReleaseNotes>Bugfix release for Incrementalist v0.1.3
+Fixed [MSBuild graph issue where two unrelated changes in the same branch could overwrite each other in the Incrementalist output](https://github.com/petabridge/Incrementalist/issues/49).
+In the event of three concurrent MSBuild dependency graphs like these:
+[A modified] Project A --&gt; B --&gt; C
+[B modified] Project B --&gt; C
+[D modified] Project D --&gt; E
+In Incrementalist 0.1.3, you'd only see this graph: `Project A --&gt; B --&gt; C` because it was the longest and "covered" all of the other graphs. In Incrementalist 0.1.4 you'll now see the following build output:
+Project A --&gt; B --&gt; C
+Project D --&gt; E
+Each line represents its own independent graph, uncovered by any of the other graphs detected in the topology of the MSBuild solution.</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIconUrl>
       https://petabridge.com/images/logo.png


### PR DESCRIPTION
#### 0.1.4 May 17 2019 ####
Bugfix release for Incrementalist v0.1.3

Fixed [MSBuild graph issue where two unrelated changes in the same branch could overwrite each other in the Incrementalist output](https://github.com/petabridge/Incrementalist/issues/49).

In the event of three concurrent MSBuild dependency graphs like these:

[A modified] Project A --> B --> C
[B modified] Project B --> C
[D modified] Project D --> E

In Incrementalist 0.1.3, you'd only see this graph: `Project A --> B --> C` because it was the longest and "covered" all of the other graphs. In Incrementalist 0.1.4 you'll now see the following build output:

Project A --> B --> C
Project D --> E

Each line represents its own independent graph, uncovered by any of the other graphs detected in the topology of the MSBuild solution.