### PR TITLE
Imported project files modifications check

### DIFF
--- a/src/Incrementalist.Tests/Dependencies/ProjectImportsTrackingSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/ProjectImportsTrackingSpecs.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Incrementalist.Git;
+using Incrementalist.ProjectSystem;
+using Incrementalist.ProjectSystem.Cmds;
+using Incrementalist.Tests.Helpers;
+using Microsoft.CodeAnalysis;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Incrementalist.Tests.Dependencies
+{
+    public class ProjectImportsTrackingSpecs : IDisposable
+    {
+        private readonly ITestOutputHelper _outputHelper;
+        public DisposableRepository Repository { get; }
+        
+        public ProjectImportsTrackingSpecs(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+            Repository = new DisposableRepository();
+        }
+
+        public void Dispose()
+        {
+            Repository?.Dispose();
+        }
+
+        [Fact(DisplayName = "List of project imported files should be loaded correctly")]
+        public void ImportedFilePathIsFound()
+        {
+            File.WriteAllText("SampleProject.csproj", ProjectSampleGenerator.GetProjectFileContent());
+            File.WriteAllText("imported.props", ProjectSampleGenerator.GetImportedPropsFileContent());
+
+            var projectFile = new SlnFileWithPath(Path.GetFullPath("SampleProject.csproj"), new SlnFile(FileType.Project, ProjectId.CreateNewId())) ;
+            var imports = ProjectImportsFinder.FindProjectImports(new[] { projectFile });
+            
+            imports.Values.Should().BeEquivalentTo(new ImportedFile(Path.GetFullPath("imported.props"), new[] { projectFile }.ToList()));
+        }
+
+        [Fact(DisplayName = "When project imported file is changed, the project should be marked as affected")]
+        public async Task Should_mark_project_as_changed_when_only_imported_file_changed()
+        {
+            Repository
+                .WriteFile("SampleProject.csproj", ProjectSampleGenerator.GetProjectFileContent())
+                .WriteFile("imported.props", ProjectSampleGenerator.GetImportedPropsFileContent())
+                .Commit("Created sample project")
+                .CreateBranch("foo")
+                .CheckoutBranch("foo")
+                .WriteFile("imported.props", ProjectSampleGenerator.GetImportedPropsFileContent() + " ")
+                .Commit("Updated imported file with a space");
+
+            var cmd = new FilterAffectedProjectFilesCmd(new TestOutputLogger(_outputHelper), new CancellationToken(), Repository.BasePath, "master");
+            var projectFilePath = Path.Combine(Repository.BasePath, "SampleProject.csproj");
+            var solutionFiles = new Dictionary<string, SlnFile>()
+            {
+                [projectFilePath] = new SlnFile(FileType.Project, ProjectId.CreateNewId())
+            };
+            var filteredAffectedFiles = await cmd.Process(Task.FromResult(solutionFiles));
+            filteredAffectedFiles.Should().HaveCount(1).And.Subject.Keys.Should().BeEquivalentTo(projectFilePath);
+        }
+    }
+}

--- a/src/Incrementalist.Tests/Dependencies/ProjectImportsTrackingSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/ProjectImportsTrackingSpecs.cs
@@ -34,13 +34,14 @@ namespace Incrementalist.Tests.Dependencies
         [Fact(DisplayName = "List of project imported files should be loaded correctly")]
         public void ImportedFilePathIsFound()
         {
-            File.WriteAllText("SampleProject.csproj", ProjectSampleGenerator.GetProjectFileContent());
-            File.WriteAllText("imported.props", ProjectSampleGenerator.GetImportedPropsFileContent());
+            Repository
+                .WriteFile("SampleProject.csproj", ProjectSampleGenerator.GetProjectFileContent())
+                .WriteFile("imported.props", ProjectSampleGenerator.GetImportedPropsFileContent());
 
-            var projectFile = new SlnFileWithPath(Path.GetFullPath("SampleProject.csproj"), new SlnFile(FileType.Project, ProjectId.CreateNewId())) ;
+            var projectFile = new SlnFileWithPath(Path.Combine(Repository.BasePath, "SampleProject.csproj"), new SlnFile(FileType.Project, ProjectId.CreateNewId())) ;
             var imports = ProjectImportsFinder.FindProjectImports(new[] { projectFile });
             
-            imports.Values.Should().BeEquivalentTo(new ImportedFile(Path.GetFullPath("imported.props"), new[] { projectFile }.ToList()));
+            imports.Values.Should().BeEquivalentTo(new ImportedFile(Path.Combine(Repository.BasePath, "imported.props"), new[] { projectFile }.ToList()));
         }
 
         [Fact(DisplayName = "When project imported file is changed, the project should be marked as affected")]

--- a/src/Incrementalist.Tests/Helpers/ProjectSampleGenerator.cs
+++ b/src/Incrementalist.Tests/Helpers/ProjectSampleGenerator.cs
@@ -1,0 +1,26 @@
+using System.IO;
+
+namespace Incrementalist.Tests.Helpers
+{
+    /// <summary>
+    /// ProjectSampleGenerator
+    /// </summary>
+    public static class ProjectSampleGenerator
+    {
+        /// <summary>
+        /// Gets project file content
+        /// </summary>
+        public static string GetProjectFileContent()
+        {
+            return File.ReadAllText("../../../Samples/ProjectFileWithImportSample.xml");
+        }
+
+        /// <summary>
+        /// Gets imported props file content
+        /// </summary>
+        public static string GetImportedPropsFileContent()
+        {
+            return File.ReadAllText("../../../Samples/ImportedPropsSample.xml");
+        }
+    }
+}

--- a/src/Incrementalist.Tests/Helpers/ProjectSampleGenerator.cs
+++ b/src/Incrementalist.Tests/Helpers/ProjectSampleGenerator.cs
@@ -8,19 +8,62 @@ namespace Incrementalist.Tests.Helpers
     public static class ProjectSampleGenerator
     {
         /// <summary>
-        /// Gets project file content
+        /// Gets project with import files sample
         /// </summary>
-        public static string GetProjectFileContent()
+        public static ProjectWithImportSample GetProjectWithImportSample()
         {
-            return File.ReadAllText("../../../Samples/ProjectFileWithImportSample.xml");
+            var projectContent = File.ReadAllText("../../../Samples/ProjectFileWithImportSample.xml");
+            var importedPropsContent = File.ReadAllText("../../../Samples/ImportedPropsSample.xml");
+            
+            return new ProjectWithImportSample(projectContent, new SampleFile("imported.props", importedPropsContent));
         }
 
         /// <summary>
-        /// Gets imported props file content
+        /// Sample files required for tests with project imports
         /// </summary>
-        public static string GetImportedPropsFileContent()
+        public class ProjectWithImportSample
         {
-            return File.ReadAllText("../../../Samples/ImportedPropsSample.xml");
+            public ProjectWithImportSample(string projectFileContent, SampleFile importedPropsFile)
+            {
+                ProjectFileContent = projectFileContent;
+                ImportedPropsFile = importedPropsFile;
+            }
+
+            /// <summary>
+            /// Content of the project file that has an Import tag
+            /// </summary>
+            /// <remarks>
+            /// Name of the file is not important here
+            /// </remarks>
+            public string ProjectFileContent { get; }
+            /// <summary>
+            /// Imported props file info
+            /// </summary>
+            /// <remarks>
+            /// Make sure using same file name in tests - it is used in a project file content
+            /// </remarks>
+            public SampleFile ImportedPropsFile { get; }
+        }
+
+        /// <summary>
+        /// Generated sample file info
+        /// </summary>
+        public class SampleFile
+        {
+            public SampleFile(string name, string content)
+            {
+                Name = name;
+                Content = content;
+            }
+
+            /// <summary>
+            /// Name of the file (might be used by another generated files)
+            /// </summary>
+            public string Name { get; }
+            /// <summary>
+            /// File content
+            /// </summary>
+            public string Content { get; }
         }
     }
 }

--- a/src/Incrementalist.Tests/Helpers/TestOutputLogger.cs
+++ b/src/Incrementalist.Tests/Helpers/TestOutputLogger.cs
@@ -1,0 +1,25 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Xunit.Abstractions;
+
+namespace Incrementalist.Tests.Helpers
+{
+    public class TestOutputLogger : ILogger
+    {
+        private readonly ITestOutputHelper _outputHelper;
+
+        public TestOutputLogger(ITestOutputHelper outputHelper)
+        {
+            _outputHelper = outputHelper;
+        }
+        
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+           _outputHelper.WriteLine(formatter(state, exception));
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable BeginScope<TState>(TState state) => null;
+    }
+}

--- a/src/Incrementalist.Tests/Samples/ImportedPropsSample.xml
+++ b/src/Incrementalist.Tests/Samples/ImportedPropsSample.xml
@@ -1,0 +1,24 @@
+<Project>
+    <PropertyGroup>
+        <Copyright>Copyright © 2015-2019 Petabridge</Copyright>
+        <Authors>Petabridge</Authors>
+        <VersionPrefix>0.1.7</VersionPrefix>
+        <PackageReleaseNotes>Bugfix release for Incrementalist v0.1.6
+            Fixed [Bug: in multi-targeted projects, only one "project" contains the dependency graph.](https://github.com/petabridge/Incrementalist/issues/63). This will make it easier for Incrementalist to detect changes that occur inside multi-targeted projects.</PackageReleaseNotes>
+        <tags>build, msbuild, incremental build, roslyn, git</tags>
+        <PackageIconUrl>
+            https://petabridge.com/images/logo.png
+        </PackageIconUrl>
+        <PackageProjectUrl>
+            https://github.com/petabridge/Incrementalist
+        </PackageProjectUrl>
+        <PackageLicenseUrl>https://cmd.petabridge.com/articles/install/license.html</PackageLicenseUrl>
+        <License>License.</License>
+        <NoWarn>$(NoWarn);CS1591</NoWarn>
+    </PropertyGroup>
+    <PropertyGroup>
+        <NBenchVersion>1.2.2</NBenchVersion>
+        <XunitVersion>2.4.1</XunitVersion>
+        <TestSdkVersion>15.9.0</TestSdkVersion>
+    </PropertyGroup>
+</Project>

--- a/src/Incrementalist.Tests/Samples/ProjectFileWithImportSample.xml
+++ b/src/Incrementalist.Tests/Samples/ProjectFileWithImportSample.xml
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="imported.props" />
+    
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <Description>Library for running incremental, Git-based builds and tests in .NET and .NET Core.</Description>
+    </PropertyGroup>
+
+
+    <ItemGroup>
+        <PackageReference Include="Libgit2Sharp" Version="0.26.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
@@ -59,7 +59,7 @@ namespace Incrementalist.ProjectSystem.Cmds
 
             var projectFiles = fileDict.Where(x => x.Value.FileType == FileType.Project).ToList();
             var projectFolders = projectFiles.ToDictionary(x => Path.GetDirectoryName(x.Key), v => Tuple.Create(v.Key, v.Value));
-            var projectImports = ProjectImportsFinder.FindProjectImports(projectFiles);
+            var projectImports = ProjectImportsFinder.FindProjectImports(projectFiles.Select(pair => new SlnFileWithPath(pair.Key, pair.Value)));
 
             // filter out any files that aren't affected by the diff
             var newDict = new Dictionary<string, SlnFile>();

--- a/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
@@ -86,7 +86,7 @@ namespace Incrementalist.ProjectSystem.Cmds
                 
                 // special case - if affected file was imported to some projects, need to mark importing project as affected
                 if (projectImports.ContainsKey(file))
-                {
+                { 
                     // Mark all dependant as affected
                     projectImports[file].DependantProjects.ForEach(dependentProject => newDict[dependentProject.Path] = dependentProject.File);
                 }

--- a/src/Incrementalist/ProjectSystem/ProjectImportsFinder.cs
+++ b/src/Incrementalist/ProjectSystem/ProjectImportsFinder.cs
@@ -1,0 +1,98 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml;
+using Microsoft.CodeAnalysis;
+
+namespace Incrementalist.ProjectSystem
+{
+    public sealed class SlnFileWithPath
+    {
+        public SlnFileWithPath(string path, SlnFile file)
+        {
+            Path = path;
+            File = file;
+        }
+
+        public string Path { get; }
+        public SlnFile File { get; }
+    }
+    
+    public sealed class ImportedFile
+    {
+        public ImportedFile(string path, List<SlnFileWithPath> dependantProjects)
+        {
+            DependantProjects = dependantProjects;
+            Path = path;
+        }
+
+        /// <summary>
+        /// List of project files that are importing this file
+        /// </summary>
+        public List<SlnFileWithPath> DependantProjects { get; }
+        /// <summary>
+        /// File path
+        /// </summary>
+        public string Path { get; }
+    }
+    
+    /// <summary>
+    /// Helps finding all imported files paths and their dependant projects
+    /// </summary>
+    public static class ProjectImportsFinder
+    {
+        /// <summary>
+        /// Finds all files that were imported to specified projec files
+        /// </summary>
+        /// <param name="projectFiles">List of project files with their paths</param>
+        /// <returns>Doctionary of imported files with their paths</returns>
+        public static Dictionary<string, ImportedFile> FindProjectImports(List<KeyValuePair<string, SlnFile>> projectFiles)
+        {
+            var imports = new ConcurrentDictionary<string, HashSet<SlnFileWithPath>>();
+            
+            Parallel.ForEach(projectFiles, projectFileInfo =>
+            {
+                var (projectPath, projectFile) = (projectFileInfo.Key, projectFileInfo.Value);
+                if (projectFile.FileType != FileType.Project)
+                    return;
+
+                var xmlDoc = ParseXmlDocument(projectPath);
+                
+                var projectDir = Path.GetDirectoryName(projectPath);
+
+                // Collecting all projects that contain imports, like <Import Project="../../common.props">
+                var importTags = xmlDoc.DocumentElement.SelectNodes("//Import");
+                foreach (XmlNode importTag in importTags)
+                {
+                    var importedFilePath = importTag.Attributes?.GetNamedItem("Project")?.Value;
+                    if (string.IsNullOrEmpty(importedFilePath))
+                        continue;
+                    
+                    var importedFileFillPath = Path.GetFullPath(Path.Combine(projectDir, importedFilePath));
+                    var dependentProjectId = projectFile.ProjectId;
+
+                    imports.AddOrUpdate(importedFileFillPath,
+                        addValue: new HashSet<SlnFileWithPath>() { new SlnFileWithPath(projectPath, projectFile) },
+                        updateValueFactory: (_, dependentProjects) =>
+                        {
+                            dependentProjects.Add(new SlnFileWithPath(projectPath, projectFile));
+                            return dependentProjects;
+                        });
+                }
+            });
+
+            return imports.ToDictionary(pair => pair.Key, pair => new ImportedFile(pair.Key, pair.Value.ToList()));
+        }
+
+        private static XmlDocument ParseXmlDocument(string projectFilePath)
+        {
+            var fileContent = File.ReadAllText(projectFilePath);
+            var xmlDoc = new XmlDocument();
+            xmlDoc.LoadXml(fileContent);
+            return xmlDoc;
+        }
+    }
+}


### PR DESCRIPTION
Close #68 

The way this is going to work is getting all imported files paths from `<Image Project="path/to/props">` tags of all projects in solution, and then checking if any of them were modified.

Will keep PR in draft until add some tests to verify this works well.