### PR TITLE
Possible NRE fix

### DIFF
--- a/src/Incrementalist.Tests/Dependencies/ProjectImportsTrackingSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/ProjectImportsTrackingSpecs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -45,7 +46,7 @@ namespace Incrementalist.Tests.Dependencies
             var projectFile = new SlnFileWithPath(projectFilePath, new SlnFile(FileType.Project, ProjectId.CreateNewId())) ;
             var imports = ProjectImportsFinder.FindProjectImports(new[] { projectFile });
             
-            imports.Values.Should().BeEquivalentTo(new ImportedFile(importedPropsFilePath, new[] { projectFile }.ToList()));
+            imports.Values.Should().BeEquivalentTo(new ImportedFile(importedPropsFilePath, new[] { projectFile }.ToImmutableList()));
         }
 
         [Fact(DisplayName = "When project imported file is changed, the project should be marked as affected")]

--- a/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
@@ -92,7 +92,10 @@ namespace Incrementalist.ProjectSystem.Cmds
                 if (projectImports.ContainsKey(file))
                 { 
                     // Mark all dependant as affected
-                    projectImports[file].DependantProjects.ForEach(dependentProject => newDict[dependentProject.Path] = dependentProject.File);
+                    foreach (var dependentProject in projectImports[file].DependantProjects)
+                    {
+                        newDict[dependentProject.Path] = dependentProject.File;
+                    }
                 }
             }
 


### PR DESCRIPTION
Close #90

Not sure if this is related, but due to `ConcurrentDictionary.AddOrUpdate` specific internal hashset could be populated with some threading issues.

Other way could be to just throw away `Parallel.ForEach` here, but... Lets try this update first.

P.S. NRE is caused by the fact that some of the elements of this hashset is `null`. Each element is taken directly from `projectFile`, which not be null by itself (it is created just before passing to  `FindProjectImports` method, and used several times before adding it to hashset).
So, the only weak place is adding to hashset, and since `updateValueFactory` is executed by `ConcurrentDictionary` without thread lock, this may give some issues. Do not see relation with NRE, but this is only place I can fix here.