### PR TITLE
v0.2.1 Release Notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,4 @@
-#### 0.2.0 October 28 2019 ####
-Feature release: Incrementalist v0.2.0
+#### 0.2.1 November 18 2019 ####
+Maintenance release: Incrementalist v0.2.1
 
-* [Added .NET Core 3.0 global tool support](https://github.com/petabridge/Incrementalist/issues/70)
-* [Added F# project support](https://github.com/petabridge/Incrementalist/issues/69)
-* [Bugfix: Need to be able to detect changes in `.props` files referenced by projects](https://github.com/petabridge/Incrementalist/issues/68)
-* [Added configurable timeout to commandline options](https://github.com/petabridge/Incrementalist/pull/86)
+* [Fixed: NRE during Incrementalist.ProjectSystem.Cmds.FilterAffectedProjectFilesCmd](https://github.com/petabridge/Incrementalist/issues/70)

--- a/src/common.props
+++ b/src/common.props
@@ -2,12 +2,9 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.2.0</VersionPrefix>
-    <PackageReleaseNotes>Feature release: Incrementalist v0.2.0
-[Added .NET Core 3.0 global tool support](https://github.com/petabridge/Incrementalist/issues/70)
-[Added F# project support](https://github.com/petabridge/Incrementalist/issues/69)
-[Bugfix: Need to be able to detect changes in `.props` files referenced by projects](https://github.com/petabridge/Incrementalist/issues/68)
-[Added configurable timeout to commandline options](https://github.com/petabridge/Incrementalist/pull/86)</PackageReleaseNotes>
+    <VersionPrefix>0.2.1</VersionPrefix>
+    <PackageReleaseNotes>Maintenance release: Incrementalist v0.2.1
+[Fixed: NRE during Incrementalist.ProjectSystem.Cmds.FilterAffectedProjectFilesCmd](https://github.com/petabridge/Incrementalist/issues/70)</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIconUrl>
       https://petabridge.com/images/logo.png


### PR DESCRIPTION
#### 0.2.1 November 18 2019 ####
Maintenance release: Incrementalist v0.2.1

* [Fixed: NRE during Incrementalist.ProjectSystem.Cmds.FilterAffectedProjectFilesCmd](https://github.com/petabridge/Incrementalist/issues/70)