### PR TITLE
added v0.2.2 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,5 @@
-#### 0.2.1 November 18 2019 ####
-Maintenance release: Incrementalist v0.2.1
+#### 0.2.2 February 14 2020 ####
+Maintenance release: Incrementalist v0.2.2
 
-* [Fixed: NRE during Incrementalist.ProjectSystem.Cmds.FilterAffectedProjectFilesCmd](https://github.com/petabridge/Incrementalist/issues/70)
+* Updated Roslyn version to 3.4.0
+* Updated Libgit2Sharp version to 0.26.2

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2019 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.2.1</VersionPrefix>
-    <PackageReleaseNotes>Maintenance release: Incrementalist v0.2.1
-[Fixed: NRE during Incrementalist.ProjectSystem.Cmds.FilterAffectedProjectFilesCmd](https://github.com/petabridge/Incrementalist/issues/70)</PackageReleaseNotes>
+    <VersionPrefix>0.2.2</VersionPrefix>
+    <PackageReleaseNotes>Maintenance release: Incrementalist v0.2.2
+Updated Roslyn version to 3.4.0
+Updated Libgit2Sharp version to 0.26.2</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIconUrl>
       https://petabridge.com/images/logo.png


### PR DESCRIPTION
#### 0.2.2 February 14 2020 ####
Maintenance release: Incrementalist v0.2.2

* Updated Roslyn version to 3.4.0
* Updated Libgit2Sharp version to 0.26.2