### PR TITLE
added v0.4.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
-#### 0.3.0 September 26 2020 ####
-New feature release: 0.3.0
+#### 0.4.0 December 23 2020 ####
+New feature release: 0.4.0
 
-* Updated Roslyn version to 3.7.0
-* Dropped .NET tool support for .NET Core 2.1 and 3.0; moved to targeting .NET Core 3.1
+* Added .NET 5 `dotnet tool` support in addition to .NET Core 3.1
+* Target Roslyn 3.8.0

--- a/src/common.props
+++ b/src/common.props
@@ -3,9 +3,9 @@
     <Copyright>Copyright © 2015-2019 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
     <VersionPrefix>0.4.0</VersionPrefix>
-    <PackageReleaseNotes>Maintenance release: Incrementalist v0.4.0
-Added dual targeting (.NET 5; .NETCore 3.1)
-</PackageReleaseNotes>
+    <PackageReleaseNotes>New feature release: 0.4.0
+Added .NET 5 `dotnet tool` support in addition to .NET Core 3.1
+Target Roslyn 3.8.0</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIconUrl>
       https://petabridge.com/images/logo.png


### PR DESCRIPTION
#### 0.4.0 December 23 2020 ####
New feature release: 0.4.0

* Added .NET 5 `dotnet tool` support in addition to .NET Core 3.1
* Target Roslyn 3.8.0
