### PR TITLE
Upgrade to Libgit2Sharp 0.27.0-preview-0156

### DIFF
--- a/src/Incrementalist/Incrementalist.csproj
+++ b/src/Incrementalist/Incrementalist.csproj
@@ -9,7 +9,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Libgit2Sharp" Version="0.26.2" />
+    <PackageReference Include="Libgit2Sharp" Version="0.27.0-preview-0156" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Should enable library to run on Ubuntu 20.04