### PR TITLE
v0.6.0 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,6 @@
-#### 0.5.0 June 16 2021 ####
-New feature release: 0.5.0
+#### 0.6.0 November 09 2021 ####
+New feature release: 0.6.0
 
-* Upgraded Roslyn, LibGit2, et al to latest.
+* Upgraded to LibGit2 experimental in order to run on newer version of Ubuntu;
+* Added .NET 6.0 `dotnet tool` support; and
+* Upgraded to .NET 6 versions of binaries.

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -16,6 +16,10 @@ jobs:
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true
       - task: UseDotNet@2
+        displayName: 'Use .NET 6 SDK 6.0.100'
+        inputs:
+          version: 6.0.100
+      - task: UseDotNet@2
         displayName: 'Use .Net 5 SDK'
         inputs:
           packageType: sdk

--- a/build-system/linux-pr-validation.yaml
+++ b/build-system/linux-pr-validation.yaml
@@ -17,6 +17,6 @@ jobs:
 - template: azure-pipeline.template.yaml
   parameters:
     name: Ubuntu
-    vmImage: 'ubuntu-16.04'
+    vmImage: 'ubuntu-20.04'
     scriptFileName: ./build.sh
     scriptArgs: all

--- a/build.fsx
+++ b/build.fsx
@@ -120,7 +120,7 @@ Target "RunTests" (fun _ ->
 Target "IntegrationTests" <| fun _ ->    
     let integrationTests = !! "./src/**/Incrementalist.Cmd.csproj"
 
-    let frameworks = ["netcoreapp3.1"; "net5.0"]
+    let frameworks = ["netcoreapp3.1"; "net5.0"; "net6.0"]
 
     let runSingleProject project fwork =
 

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -4,7 +4,7 @@
     <ToolCommandName>incrementalist</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <LangVersion>7.1</LangVersion>
     <Description>.NET Core global tool for determining how to run incremental builds based on the current Git diff.</Description>

--- a/src/Incrementalist/Incrementalist.csproj
+++ b/src/Incrementalist/Incrementalist.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Libgit2Sharp" Version="0.27.0-preview-0156" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Incrementalist/Incrementalist.csproj
+++ b/src/Incrementalist/Incrementalist.csproj
@@ -9,7 +9,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Libgit2Sharp" Version="0.26.2" />
+    <PackageReference Include="Libgit2Sharp" Version="0.27.0-preview-0156" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
   </ItemGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -224,6 +224,6 @@ Target Roslyn 3.8.0</PackageReleaseNotes>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.10.0</TestSdkVersion>
     <RoslynVersion>3.11.0</RoslynVersion>
-    <NugetVersion>5.10.0</NugetVersion>
+    <NugetVersion>6.0.0</NugetVersion>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -1,11 +1,10 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2015-2019 Petabridge</Copyright>
+    <Copyright>Copyright © 2015-2021 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.4.0</VersionPrefix>
-    <PackageReleaseNotes>New feature release: 0.4.0
-Added .NET 5 `dotnet tool` support in addition to .NET Core 3.1
-Target Roslyn 3.8.0</PackageReleaseNotes>
+    <VersionPrefix>0.5.0</VersionPrefix>
+    <PackageReleaseNotes>New feature release: 0.5.0
+Upgraded Roslyn, LibGit2, et al to latest.</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIconUrl>
       https://petabridge.com/images/logo.png
@@ -13,7 +12,6 @@ Target Roslyn 3.8.0</PackageReleaseNotes>
     <PackageProjectUrl>
       https://github.com/petabridge/Incrementalist
     </PackageProjectUrl>
-    <PackageLicenseUrl>https://cmd.petabridge.com/articles/install/license.html</PackageLicenseUrl>
     <License>
                                        Apache License
                            Version 2.0, January 2004
@@ -203,7 +201,7 @@ Target Roslyn 3.8.0</PackageReleaseNotes>
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015-2020 Petabridge, LLC
+   Copyright 2015-2021 Petabridge, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/common.props
+++ b/src/common.props
@@ -223,7 +223,7 @@ Target Roslyn 3.8.0</PackageReleaseNotes>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.1</XunitVersion>
     <TestSdkVersion>16.10.0</TestSdkVersion>
-    <RoslynVersion>3.10.0</RoslynVersion>
+    <RoslynVersion>3.11.0</RoslynVersion>
     <NugetVersion>5.10.0</NugetVersion>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2021 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.5.0</VersionPrefix>
-    <PackageReleaseNotes>New feature release: 0.5.0
-Upgraded Roslyn, LibGit2, et al to latest.</PackageReleaseNotes>
+    <VersionPrefix>0.6.0</VersionPrefix>
+    <PackageReleaseNotes>New feature release: 0.6.0
+Upgraded to LibGit2 experimental in order to run on newer version of Ubuntu;
+Added .NET 6.0 `dotnet tool` support; and
+Upgraded to .NET 6 versions of binaries.</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIconUrl>
       https://petabridge.com/images/logo.png

--- a/src/common.props
+++ b/src/common.props
@@ -222,7 +222,7 @@ Target Roslyn 3.8.0</PackageReleaseNotes>
   <PropertyGroup>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.1</XunitVersion>
-    <TestSdkVersion>16.10.0</TestSdkVersion>
+    <TestSdkVersion>17.0.0</TestSdkVersion>
     <RoslynVersion>3.11.0</RoslynVersion>
     <NugetVersion>6.0.0</NugetVersion>
   </PropertyGroup>


### PR DESCRIPTION
#### 0.6.0 November 09 2021 ####
New feature release: 0.6.0

* Upgraded to LibGit2 experimental in order to run on newer version of Ubuntu;
* Added .NET 6.0 `dotnet tool` support; and
* Upgraded to .NET 6 versions of binaries.