### PR TITLE
Releasenotes/0.7.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,5 @@
-#### 0.6.0 November 09 2021 ####
-New feature release: 0.6.0
+#### 0.7.0 May 24 2022 ####
 
-* Upgraded to LibGit2 experimental in order to run on newer version of Ubuntu;
-* Added .NET 6.0 `dotnet tool` support; and
-* Upgraded to .NET 6 versions of binaries.
+* Upgraded from Roslyn 3.11 to 4.2.0;
+* Upgraded NuGet.ProjectModel to 6.2.0; and
+* Upgraded Libgit2Sharp to 0.27.0-preview-0182.

--- a/src/common.props
+++ b/src/common.props
@@ -2,11 +2,10 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2022 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.6.0</VersionPrefix>
-    <PackageReleaseNotes>New feature release: 0.6.0
-Upgraded to LibGit2 experimental in order to run on newer version of Ubuntu;
-Added .NET 6.0 `dotnet tool` support; and
-Upgraded to .NET 6 versions of binaries.</PackageReleaseNotes>
+    <VersionPrefix>0.7.0</VersionPrefix>
+    <PackageReleaseNotes>Upgraded from Roslyn 3.11 to 4.2.0;
+Upgraded NuGet.ProjectModel to 6.2.0; and
+Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIconUrl>
       https://petabridge.com/images/logo.png

--- a/src/common.props
+++ b/src/common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Copyright>Copyright © 2015-2021 Petabridge</Copyright>
+    <Copyright>Copyright © 2015-2022 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
     <VersionPrefix>0.6.0</VersionPrefix>
     <PackageReleaseNotes>New feature release: 0.6.0


### PR DESCRIPTION
#### 0.7.0 May 24 2022 ####

* Upgraded from Roslyn 3.11 to 4.2.0;
* Upgraded NuGet.ProjectModel to 6.2.0; and
* Upgraded Libgit2Sharp to 0.27.0-preview-0182.