### PR TITLE
Incrementalist v0.8.0 Release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
-#### 0.7.0 May 24 2022 ####
+#### 0.8.0 November 24 2022 ####
 
-* Upgraded from Roslyn 3.11 to 4.2.0;
-* Upgraded NuGet.ProjectModel to 6.2.0; and
-* Upgraded Libgit2Sharp to 0.27.0-preview-0182.
+* Added .NET 7.0 support to `Incrementalist.Cmd`;
+* Dropped .NET 5.0 support from `Incrementalist.Cmd`;
+* Upgraded to Roslyn 4.4.0; and
+* Upgraded to NuGet.ProjectModel 6.4.0.

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -16,9 +16,9 @@ jobs:
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true
       - task: UseDotNet@2
-        displayName: 'Use .NET 6 SDK 6.0.100'
+        displayName: 'Use .NET 6 SDK 6.0.403'
         inputs:
-          version: 6.0.100
+          version: 6.0.403
       - task: UseDotNet@2
         displayName: 'Use .Net 5 SDK'
         inputs:

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -16,19 +16,18 @@ jobs:
         submodules: recursive  # set to 'true' for a single level of submodules or 'recursive' to get submodules of submodules
         persistCredentials: true
       - task: UseDotNet@2
-        displayName: 'Use .NET 6 SDK 6.0.403'
-        inputs:
-          version: 6.0.403
-      - task: UseDotNet@2
-        displayName: 'Use .Net 5 SDK'
-        inputs:
-          packageType: sdk
-          version: 5.0.101   
-      - task: UseDotNet@2
         displayName: 'Use .NET Core SDK 3.1.105'
         inputs:
           packageType: sdk
           version: 3.1.105 
+      - task: UseDotNet@2
+        displayName: 'Use .NET 6 SDK 6.0.403'
+        inputs:
+          version: 6.0.403
+      - task: UseDotNet@2
+        displayName: 'Use .NET 7 SDK 7.0.100'
+        inputs:
+          version:  7.0.100
       # Linux or macOS
       - task: Bash@3 
         displayName: Linux / OSX Build

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -22,9 +22,9 @@ variables:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET 6 SDK 6.0.100'
+  displayName: 'Use .NET 7 SDK 7.0.100'
   inputs:
-    version: 6.0.100
+    version:  7.0.100
 - task: BatchScript@1
   displayName: 'FAKE Build'
   inputs:

--- a/build.fsx
+++ b/build.fsx
@@ -120,7 +120,7 @@ Target "RunTests" (fun _ ->
 Target "IntegrationTests" <| fun _ ->    
     let integrationTests = !! "./src/**/Incrementalist.Cmd.csproj"
 
-    let frameworks = ["netcoreapp3.1"; "net5.0"; "net6.0"]
+    let frameworks = ["netcoreapp3.1"; "net6.0"; "net7.0"]
 
     let runSingleProject project fwork =
 

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -4,7 +4,7 @@
     <ToolCommandName>incrementalist</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <LangVersion>7.1</LangVersion>
     <Description>.NET Core global tool for determining how to run incremental builds based on the current Git diff.</Description>

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(RoslynVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NugetVersion)" />

--- a/src/Incrementalist.Tests/Incrementalist.Tests.csproj
+++ b/src/Incrementalist.Tests/Incrementalist.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>    
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -2,10 +2,11 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-2022 Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>0.7.0</VersionPrefix>
-    <PackageReleaseNotes>Upgraded from Roslyn 3.11 to 4.2.0;
-Upgraded NuGet.ProjectModel to 6.2.0; and
-Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
+    <VersionPrefix>0.8.0</VersionPrefix>
+    <PackageReleaseNotes>Added .NET 7.0 support to `Incrementalist.Cmd`;
+Dropped .NET 5.0 support from `Incrementalist.Cmd`;
+Upgraded to Roslyn 4.4.0; and
+Upgraded to NuGet.ProjectModel 6.4.0.</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIconUrl>
       https://petabridge.com/images/logo.png
@@ -216,6 +217,7 @@ Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
    See the License for the specific language governing permissions and
    limitations under the License.
     </License>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
@@ -225,4 +227,7 @@ Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
     <RoslynVersion>4.4.0</RoslynVersion>
     <NugetVersion>6.4.0</NugetVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)\..\README.md" Pack="true" Visible="false" PackagePath="\" />
+  </ItemGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -222,7 +222,7 @@ Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.2</XunitVersion>
     <TestSdkVersion>17.3.0</TestSdkVersion>
-    <RoslynVersion>4.2.0</RoslynVersion>
+    <RoslynVersion>4.3.1</RoslynVersion>
     <NugetVersion>6.2.0</NugetVersion>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -220,7 +220,7 @@ Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <NBenchVersion>1.2.2</NBenchVersion>
-    <XunitVersion>2.4.1</XunitVersion>
+    <XunitVersion>2.4.2</XunitVersion>
     <TestSdkVersion>17.2.0</TestSdkVersion>
     <RoslynVersion>4.2.0</RoslynVersion>
     <NugetVersion>6.2.0</NugetVersion>

--- a/src/common.props
+++ b/src/common.props
@@ -221,7 +221,7 @@ Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
   <PropertyGroup>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.2</XunitVersion>
-    <TestSdkVersion>17.3.2</TestSdkVersion>
+    <TestSdkVersion>17.4.0</TestSdkVersion>
     <RoslynVersion>4.4.0</RoslynVersion>
     <NugetVersion>6.4.0</NugetVersion>
   </PropertyGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -221,7 +221,7 @@ Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
   <PropertyGroup>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.2</XunitVersion>
-    <TestSdkVersion>17.2.0</TestSdkVersion>
+    <TestSdkVersion>17.3.0</TestSdkVersion>
     <RoslynVersion>4.2.0</RoslynVersion>
     <NugetVersion>6.2.0</NugetVersion>
   </PropertyGroup>

--- a/src/common.props
+++ b/src/common.props
@@ -223,6 +223,6 @@ Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
     <XunitVersion>2.4.2</XunitVersion>
     <TestSdkVersion>17.3.2</TestSdkVersion>
     <RoslynVersion>4.4.0</RoslynVersion>
-    <NugetVersion>6.2.0</NugetVersion>
+    <NugetVersion>6.4.0</NugetVersion>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -222,7 +222,7 @@ Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.2</XunitVersion>
     <TestSdkVersion>17.3.2</TestSdkVersion>
-    <RoslynVersion>4.3.1</RoslynVersion>
+    <RoslynVersion>4.4.0</RoslynVersion>
     <NugetVersion>6.2.0</NugetVersion>
   </PropertyGroup>
 </Project>

--- a/src/common.props
+++ b/src/common.props
@@ -221,7 +221,7 @@ Upgraded Libgit2Sharp to 0.27.0-preview-0182.</PackageReleaseNotes>
   <PropertyGroup>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.4.2</XunitVersion>
-    <TestSdkVersion>17.3.0</TestSdkVersion>
+    <TestSdkVersion>17.3.2</TestSdkVersion>
     <RoslynVersion>4.3.1</RoslynVersion>
     <NugetVersion>6.2.0</NugetVersion>
   </PropertyGroup>


### PR DESCRIPTION
#### 0.8.0 November 24 2022 ####

* Added .NET 7.0 support to `Incrementalist.Cmd`;
* Dropped .NET 5.0 support from `Incrementalist.Cmd`;
* Upgraded to Roslyn 4.4.0; and
* Upgraded to NuGet.ProjectModel 6.4.0.