### PR TITLE
support solution-wide building when it's the better option

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,8 +8,8 @@
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.7.8" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(RoslynVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
     <PackageVersion Include="NuGet.ProjectModel" Version="$(NugetVersion)" />
   </ItemGroup>
 

--- a/src/Incrementalist.Cmd/Commands/EmitDependencyGraphTask.cs
+++ b/src/Incrementalist.Cmd/Commands/EmitDependencyGraphTask.cs
@@ -4,56 +4,96 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Incrementalist.Git;
 using Incrementalist.ProjectSystem;
 using Incrementalist.ProjectSystem.Cmds;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.Extensions.Logging;
 
 namespace Incrementalist.Cmd.Commands
 {
     /// <summary>
-    ///     Used to emit an entire dependency graph based on which files in
-    ///     a solution were affected.
+    /// Analyzes changes and determines whether a full solution build or incremental build is required.
     /// </summary>
     public sealed class EmitDependencyGraphTask
     {
         private readonly CancellationTokenSource _cts;
 
-        private readonly MSBuildWorkspace _workspace;
-
         public EmitDependencyGraphTask(BuildSettings settings, MSBuildWorkspace workspace, ILogger logger)
         {
             Settings = settings;
-            _workspace = workspace;
+            Workspace = workspace;
             Logger = logger;
             _cts = new CancellationTokenSource();
         }
 
         public BuildSettings Settings { get; }
 
+        public MSBuildWorkspace Workspace { get; }
+
         public ILogger Logger { get; }
 
-        public async Task<Dictionary<string, ICollection<string>>> Run()
+        public async Task<BuildAnalysisResult> Run()
         {
             // start the cancellation timer.
             _cts.CancelAfter(Settings.TimeoutDuration);
 
-            var loadSln = new LoadSolutionCmd(Logger, _workspace, _cts.Token);
-            var slnFile = await loadSln.Process(Task.FromResult(Settings.SolutionFile));
-
+            var solution = await Workspace.OpenSolutionAsync(Settings.SolutionFile, null, _cts.Token);
 
             var getFilesCmd = new GatherAllFilesInSolutionCmd(Logger, _cts.Token, Settings.WorkingDirectory);
-            var filterFilesCmd =
-                new FilterAffectedProjectFilesCmd(Logger, _cts.Token, Settings.WorkingDirectory, Settings.TargetBranch);
-            var createDependencyGraph = new ComputeDependencyGraphCmd(Logger, _cts.Token, slnFile);
-            var affectedFiles =
-                await createDependencyGraph.Process(
-                    filterFilesCmd.Process(getFilesCmd.Process(Task.FromResult(slnFile))));
-            return affectedFiles;
+            var filterFilesCmd = new FilterAffectedProjectFilesCmd(Logger, _cts.Token, Settings.WorkingDirectory, Settings.TargetBranch);
+
+            // Get all files and filter affected ones
+            var allFiles = await getFilesCmd.Process(Task.FromResult(solution));
+            var affectedFiles = await filterFilesCmd.Process(Task.FromResult(allFiles));
+
+            // Early check: if no files are affected, return an incremental build with empty list
+            if (!affectedFiles.Any())
+            {
+                Logger.LogInformation("No files were affected by the changes");
+                return new IncrementalBuildResult(Array.Empty<string>());
+            }
+
+            // Check if any of the affected files require a solution-wide build
+            var projectFiles = allFiles.Where(x => x.Value.FileType == FileType.Project)
+                                     .Select(pair => new SlnFileWithPath(pair.Key, pair.Value))
+                                     .ToList();
+            var projectImports = ProjectImportsFinder.FindProjectImports(projectFiles);
+            var detector = new SolutionWideChangeDetector(projectImports);
+
+            if (detector.RequiresFullSolutionBuild(affectedFiles.Keys))
+            {
+                Logger.LogInformation("Solution-wide changes detected. Full solution build required");
+                return new FullSolutionBuildResult(solution.FilePath);
+            }
+
+            // Get the list of affected projects
+            var affectedProjects = affectedFiles.Where(x => x.Value.FileType == FileType.Project)
+                                              .Select(x => x.Key)
+                                              .ToList();
+
+            // If all projects are affected, return a full solution build
+            if (affectedProjects.Count == solution.Projects.Count())
+            {
+                Logger.LogInformation("All projects are affected. Full solution build required");
+                return new FullSolutionBuildResult(solution.FilePath);
+            }
+
+            // For incremental builds, compute the dependency graph
+            var createDependencyGraph = new ComputeDependencyGraphCmd(Logger, _cts.Token, solution);
+            var dependencyGraph = await createDependencyGraph.Process(Task.FromResult(affectedFiles));
+
+            // Convert the dependency graph to a list of affected projects
+            var projectsToRebuild = dependencyGraph.SelectMany(x => x.Value).Distinct().ToList();
+            
+            Logger.LogInformation($"Incremental build possible. {projectsToRebuild.Count} projects need to be rebuilt");
+            return new IncrementalBuildResult(projectsToRebuild);
         }
     }
 }

--- a/src/Incrementalist.Cmd/Commands/RunDotNetCommandTask.cs
+++ b/src/Incrementalist.Cmd/Commands/RunDotNetCommandTask.cs
@@ -35,7 +35,26 @@ namespace Incrementalist.Cmd.Commands
             _failOnNoProjects = failOnNoProjects;
         }
 
-        public async Task<int> Run(IEnumerable<string> affectedProjects)
+        public async Task<int> Run(BuildAnalysisResult buildResult)
+        {
+            switch (buildResult)
+            {
+                case FullSolutionBuildResult full:
+                    return await RunSolutionBuild(full.SolutionPath);
+                case IncrementalBuildResult incremental:
+                    return await RunIncrementalBuild(incremental.AffectedProjects);
+                default:
+                    throw new InvalidOperationException($"Unknown build result type: {buildResult.GetType()}");
+            }
+        }
+
+        private async Task<int> RunSolutionBuild(string solutionPath)
+        {
+            _logger.LogInformation("Running '{0}' against solution {1}", string.Join(" ", _dotnetArgs), solutionPath);
+            return await RunCommand(solutionPath);
+        }
+
+        private async Task<int> RunIncrementalBuild(IEnumerable<string> affectedProjects)
         {
             var projects = affectedProjects.ToList();
             if (!projects.Any())
@@ -48,69 +67,11 @@ namespace Incrementalist.Cmd.Commands
             
             var failedProjects = new List<string>();
             
-            async Task<bool> RunCommand(string project)
-            {
-                // For dotnet CLI commands like 'build', 'test', etc., the project path comes last
-                var args = string.Join(" ", _dotnetArgs);
-                if (!args.Contains("--project") && !args.Contains("-p"))
-                    args = $"{args} \"{project}\"";
-
-                var process = new Process
-                {
-                    StartInfo = new ProcessStartInfo
-                    {
-                        FileName = "dotnet",
-                        Arguments = args,
-                        UseShellExecute = false,
-                        RedirectStandardOutput = true,
-                        RedirectStandardError = true,
-                        WorkingDirectory = _settings.WorkingDirectory
-                    }
-                };
-
-                process.OutputDataReceived += (sender, eventArgs) =>
-                {
-                    if (!string.IsNullOrEmpty(eventArgs.Data))
-                        _logger.LogInformation("[{0}] {1}", project, eventArgs.Data);
-                };
-
-                process.ErrorDataReceived += (sender, eventArgs) =>
-                {
-                    if (!string.IsNullOrEmpty(eventArgs.Data))
-                        _logger.LogError("[{0}] {1}", project, eventArgs.Data);
-                };
-
-                try
-                {
-                    process.Start();
-                    process.BeginOutputReadLine();
-                    process.BeginErrorReadLine();
-                    await process.WaitForExitAsync();
-                    
-                    if (process.ExitCode != 0)
-                    {
-                        _logger.LogError("Command failed for project {0} with exit code {1}", project, process.ExitCode);
-                        return false;
-                    }
-                    
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Failed to execute command for project {0}", project);
-                    return false;
-                }
-                finally
-                {
-                    process.Dispose();
-                }
-            }
-
             if (_runInParallel)
             {
                 var tasks = projects.Select(async project =>
                 {
-                    if (!await RunCommand(project))
+                    if (await RunCommand(project) != 0)
                     {
                         failedProjects.Add(project);
                         if (!_continueOnError)
@@ -124,7 +85,7 @@ namespace Incrementalist.Cmd.Commands
             {
                 foreach (var project in projects)
                 {
-                    if (!await RunCommand(project))
+                    if (await RunCommand(project) != 0)
                     {
                         failedProjects.Add(project);
                         if (!_continueOnError)
@@ -140,6 +101,63 @@ namespace Incrementalist.Cmd.Commands
             }
 
             return 0;
+        }
+
+        private async Task<int> RunCommand(string target)
+        {
+            // For dotnet CLI commands like 'build', 'test', etc., the project/solution path comes last
+            var args = string.Join(" ", _dotnetArgs);
+            if (!args.Contains("--project") && !args.Contains("-p"))
+                args = $"{args} \"{target}\"";
+
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "dotnet",
+                    Arguments = args,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    WorkingDirectory = _settings.WorkingDirectory
+                }
+            };
+
+            process.OutputDataReceived += (sender, eventArgs) =>
+            {
+                if (!string.IsNullOrEmpty(eventArgs.Data))
+                    _logger.LogInformation("[{0}] {1}", target, eventArgs.Data);
+            };
+
+            process.ErrorDataReceived += (sender, eventArgs) =>
+            {
+                if (!string.IsNullOrEmpty(eventArgs.Data))
+                    _logger.LogError("[{0}] {1}", target, eventArgs.Data);
+            };
+
+            try
+            {
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                await process.WaitForExitAsync();
+                
+                if (process.ExitCode != 0)
+                {
+                    _logger.LogError("Command failed for {0} with exit code {1}", target, process.ExitCode);
+                }
+                
+                return process.ExitCode;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to execute command for {0}", target);
+                return 1;
+            }
+            finally
+            {
+                process.Dispose();
+            }
         }
     }
 } 

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="CommandLineParser"/>
     <PackageReference Include="Microsoft.Build.Locator"/>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild"/>
-    <PackageReference Include="Microsoft.Extensions.Logging"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
     <PackageReference Include="NuGet.ProjectModel" />
   </ItemGroup>

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="CommandLineParser"/>
     <PackageReference Include="Microsoft.Build.Locator"/>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild"/>
+    <PackageReference Include="Microsoft.Extensions.Logging"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
     <PackageReference Include="NuGet.ProjectModel" />
   </ItemGroup>

--- a/src/Incrementalist.Cmd/Program.cs
+++ b/src/Incrementalist.Cmd/Program.cs
@@ -175,22 +175,65 @@ namespace Incrementalist.Cmd
             var settings = new BuildSettings(options.GitBranch, sln, workingFolder.FullName,
                 TimeSpan.FromMinutes(options.TimeoutMinutes));
             var emitTask = new EmitDependencyGraphTask(settings, msBuild, logger);
-            var affectedFiles = (await emitTask.Run()).ToList();
+            var buildResult = await emitTask.Run();
 
             if (options.RunCommand && options.DotNetArgs.Length > 0)
             {
                 var runTask = new RunDotNetCommandTask(settings, logger, options.DotNetArgs, 
                     options.ContinueOnError, options.RunInParallel, options.FailOnNoProjects);
-                var exitCode = await runTask.Run(affectedFiles.SelectMany(x => x.Value));
+
+                var projectsToRebuild = buildResult switch
+                {
+                    FullSolutionBuildResult full => msBuild.CurrentSolution.Projects.Select(p => p.FilePath),
+                    IncrementalBuildResult incremental => incremental.AffectedProjects,
+                    _ => throw new InvalidOperationException($"Unknown build result type: {buildResult.GetType()}")
+                };
+
+                var exitCode = await runTask.Run(projectsToRebuild);
                 if (exitCode != 0)
                     throw new Exception($"Command execution failed with exit code {exitCode}");
             }
             else
             {
-                var affectedFilesStr =
-                    string.Join(Environment.NewLine, affectedFiles.Select(x => string.Join(",", x.Value)));
+                string buildType;
+                IEnumerable<string> projectsToRebuild;
 
-                HandleAffectedFiles(options, affectedFilesStr, affectedFiles.Count);
+                switch (buildResult)
+                {
+                    case FullSolutionBuildResult _:
+                        buildType = "Full solution build";
+                        projectsToRebuild = msBuild.CurrentSolution.Projects.Select(p => p.FilePath);
+                        break;
+                    case IncrementalBuildResult incremental:
+                        buildType = "Incremental build";
+                        projectsToRebuild = incremental.AffectedProjects;
+                        break;
+                    default:
+                        throw new InvalidOperationException($"Unknown build result type: {buildResult.GetType()}");
+                }
+
+                if (!projectsToRebuild.Any())
+                {
+                    Console.WriteLine("No changes detected by Incrementalist when analyzing solution");
+                    return;
+                }
+
+                var affectedFilesStr = string.Join(Environment.NewLine, projectsToRebuild);
+
+                // Check to see if we're planning on writing out to the file system or not.
+                if (!string.IsNullOrEmpty(options.OutputFile))
+                {
+                    Console.WriteLine("{0} required - {1} affected projects - writing out to {2}", 
+                        buildType,
+                        projectsToRebuild.Count(),
+                        options.OutputFile);
+                    File.WriteAllText(options.OutputFile, affectedFilesStr);
+                }
+                else
+                {
+                    Console.WriteLine("{0} required:", buildType);
+                    Console.WriteLine(affectedFilesStr);
+                }
             }
         }
 
@@ -210,7 +253,6 @@ namespace Incrementalist.Cmd
                     options.ListFolders ? "folders" : "projects in solution", options.OutputFile);
                 File.WriteAllText(options.OutputFile, affectedFilesStr);
             }
-
             else
                 Console.WriteLine(affectedFilesStr);
         }

--- a/src/Incrementalist.Cmd/Program.cs
+++ b/src/Incrementalist.Cmd/Program.cs
@@ -182,14 +182,7 @@ namespace Incrementalist.Cmd
                 var runTask = new RunDotNetCommandTask(settings, logger, options.DotNetArgs, 
                     options.ContinueOnError, options.RunInParallel, options.FailOnNoProjects);
 
-                var projectsToRebuild = buildResult switch
-                {
-                    FullSolutionBuildResult full => msBuild.CurrentSolution.Projects.Select(p => p.FilePath),
-                    IncrementalBuildResult incremental => incremental.AffectedProjects,
-                    _ => throw new InvalidOperationException($"Unknown build result type: {buildResult.GetType()}")
-                };
-
-                var exitCode = await runTask.Run(projectsToRebuild);
+                var exitCode = await runTask.Run(buildResult);
                 if (exitCode != 0)
                     throw new Exception($"Command execution failed with exit code {exitCode}");
             }

--- a/src/Incrementalist.Cmd/Program.cs
+++ b/src/Incrementalist.Cmd/Program.cs
@@ -102,8 +102,7 @@ namespace Incrementalist.Cmd
 
                 if (!repoResult.foundRepo)
                 {
-                    Console.WriteLine("Unable to find Git repository located in {0}. Shutting down.",
-                        workingFolder.FullName);
+                    logger.LogError("Unable to find Git repository located in {0}. Shutting down.", workingFolder.FullName);
                     return -3;
                 }
 
@@ -115,12 +114,11 @@ namespace Incrementalist.Cmd
                     options.GitBranch = $"origin/{options.GitBranch}";
                     if (!DiffHelper.HasBranch(repoResult.repo, options.GitBranch))
                     {
-                        Console.WriteLine("Current git repository doesn't have any branch named [{0}]. Shutting down.",
-                            options.GitBranch);
-                        Console.WriteLine("[Debug] Here are all of the currently known branches in this repository");
+                        logger.LogError("Current git repository doesn't have any branch named [{0}]. Shutting down.", options.GitBranch);
+                        logger.LogDebug("Here are all of the currently known branches in this repository:");
                         foreach (var b in repoResult.repo.Branches)
                         {
-                            Console.WriteLine(b.FriendlyName);
+                            logger.LogDebug(b.FriendlyName);
                         }
 
                         return -4;
@@ -153,7 +151,7 @@ namespace Incrementalist.Cmd
 
             var affectedFilesStr = string.Join(",", affectedFiles.Keys);
 
-            HandleAffectedFiles(options, affectedFilesStr, affectedFiles.Count);
+            HandleAffectedFiles(options, affectedFilesStr, affectedFiles.Count, logger);
         }
 
         private static async Task AnaylzeSolutionDIff(SlnOptions options, DirectoryInfo workingFolder, ILogger logger)
@@ -207,7 +205,7 @@ namespace Incrementalist.Cmd
 
                 if (!projectsToRebuild.Any())
                 {
-                    Console.WriteLine("No changes detected by Incrementalist when analyzing solution");
+                    logger.LogInformation("No changes detected by Incrementalist when analyzing solution");
                     return;
                 }
 
@@ -216,7 +214,7 @@ namespace Incrementalist.Cmd
                 // Check to see if we're planning on writing out to the file system or not.
                 if (!string.IsNullOrEmpty(options.OutputFile))
                 {
-                    Console.WriteLine("{0} required - {1} affected projects - writing out to {2}", 
+                    logger.LogInformation("{0} required - {1} affected projects - writing out to {2}", 
                         buildType,
                         projectsToRebuild.Count(),
                         options.OutputFile);
@@ -224,17 +222,17 @@ namespace Incrementalist.Cmd
                 }
                 else
                 {
-                    Console.WriteLine("{0} required:", buildType);
-                    Console.WriteLine(affectedFilesStr);
+                    logger.LogInformation("{0} required:", buildType);
+                    logger.LogInformation(affectedFilesStr);
                 }
             }
         }
 
-        private static void HandleAffectedFiles(SlnOptions options, string affectedFilesStr, int affectedFilesCount)
+        private static void HandleAffectedFiles(SlnOptions options, string affectedFilesStr, int affectedFilesCount, ILogger logger)
         {
             if (affectedFilesCount == 0)
             {
-                Console.WriteLine("No changes detected by Incrementalist when analyzing {0}.",
+                logger.LogInformation("No changes detected by Incrementalist when analyzing {0}.",
                     options.ListFolders ? "repository folders" : "solution");
                 return;
             }
@@ -242,12 +240,12 @@ namespace Incrementalist.Cmd
             // Check to see if we're planning on writing out to the file system or not.
             if (!string.IsNullOrEmpty(options.OutputFile))
             {
-                Console.WriteLine("Detected {0} affected {1} - writing out to {2}", affectedFilesCount,
+                logger.LogInformation("Detected {0} affected {1} - writing out to {2}", affectedFilesCount,
                     options.ListFolders ? "folders" : "projects in solution", options.OutputFile);
                 File.WriteAllText(options.OutputFile, affectedFilesStr);
             }
             else
-                Console.WriteLine(affectedFilesStr);
+                logger.LogInformation(affectedFilesStr);
         }
     }
 }

--- a/src/Incrementalist.Tests/BuildAnalysisResultTests.cs
+++ b/src/Incrementalist.Tests/BuildAnalysisResultTests.cs
@@ -5,6 +5,10 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Incrementalist.Tests
@@ -37,6 +41,97 @@ namespace Incrementalist.Tests
         public void FullSolutionBuildResult_Constructor_ThrowsOnNull()
         {
             Assert.Throws<ArgumentNullException>(() => new FullSolutionBuildResult(null));
+        }
+
+        [Fact]
+        public void CreateBuildResult_AllProjectsAffected_ReturnsFullSolutionBuildResult()
+        {
+            // Arrange
+            var solutionPath = "test.sln";
+            var workspace = new AdhocWorkspace();
+            var solutionInfo = SolutionInfo.Create(
+                SolutionId.CreateNewId(),
+                VersionStamp.Create(),
+                solutionPath);
+            
+            var solution = workspace.AddSolution(solutionInfo);
+
+            var projectIds = new[] { ProjectId.CreateNewId(), ProjectId.CreateNewId() };
+            foreach (var id in projectIds)
+            {
+                var projectInfo = ProjectInfo.Create(
+                    id,
+                    VersionStamp.Create(),
+                    $"Project{id.Id}",
+                    $"Project{id.Id}",
+                    LanguageNames.CSharp,
+                    filePath: $"Project{id.Id}.csproj");
+                solution = solution.AddProject(projectInfo);
+            }
+
+            var affectedProjects = new[] { "Project1.csproj", "Project2.csproj" };
+
+            // Act
+            var result = SolutionWideChangeDetector.CreateBuildResult(solution, affectedProjects);
+
+            // Assert
+            Assert.IsType<FullSolutionBuildResult>(result);
+            var fullResult = (FullSolutionBuildResult)result;
+            Assert.Equal(solutionPath, fullResult.SolutionPath);
+        }
+
+        [Fact]
+        public void CreateBuildResult_SomeProjectsAffected_ReturnsIncrementalBuildResult()
+        {
+            // Arrange
+            var solutionPath = "test.sln";
+            var workspace = new AdhocWorkspace();
+            var solutionInfo = SolutionInfo.Create(
+                SolutionId.CreateNewId(),
+                VersionStamp.Create(),
+                solutionPath);
+            
+            var solution = workspace.AddSolution(solutionInfo);
+
+            var projectIds = new[] { ProjectId.CreateNewId(), ProjectId.CreateNewId(), ProjectId.CreateNewId() };
+            foreach (var id in projectIds)
+            {
+                var projectInfo = ProjectInfo.Create(
+                    id,
+                    VersionStamp.Create(),
+                    $"Project{id.Id}",
+                    $"Project{id.Id}",
+                    LanguageNames.CSharp,
+                    filePath: $"Project{id.Id}.csproj");
+                solution = solution.AddProject(projectInfo);
+            }
+
+            var affectedProjects = new[] { "Project1.csproj", "Project2.csproj" }; // Only 2 of 3 projects affected
+
+            // Act
+            var result = SolutionWideChangeDetector.CreateBuildResult(solution, affectedProjects);
+
+            // Assert
+            Assert.IsType<IncrementalBuildResult>(result);
+            var incrementalResult = (IncrementalBuildResult)result;
+            Assert.Equal(affectedProjects, incrementalResult.AffectedProjects);
+        }
+
+        [Fact]
+        public void CreateBuildResult_NullSolution_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => SolutionWideChangeDetector.CreateBuildResult(null, new[] { "Project1.csproj" }));
+        }
+
+        [Fact]
+        public void CreateBuildResult_NullAffectedProjects_ThrowsArgumentNullException()
+        {
+            var workspace = new AdhocWorkspace();
+            var solution = workspace.AddSolution(SolutionInfo.Create(
+                SolutionId.CreateNewId(),
+                VersionStamp.Create(),
+                "test.sln"));
+            Assert.Throws<ArgumentNullException>(() => SolutionWideChangeDetector.CreateBuildResult(solution, null));
         }
     }
 } 

--- a/src/Incrementalist.Tests/BuildAnalysisResultTests.cs
+++ b/src/Incrementalist.Tests/BuildAnalysisResultTests.cs
@@ -1,0 +1,42 @@
+// -----------------------------------------------------------------------
+// <copyright file="BuildAnalysisResultTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Incrementalist.Tests
+{
+    public class BuildAnalysisResultTests
+    {
+        [Fact]
+        public void IncrementalBuildResult_Constructor_ValidatesInput()
+        {
+            var projects = new[] { "Project1.csproj", "Project2.csproj" };
+            var result = new IncrementalBuildResult(projects);
+            Assert.Equal(projects, result.AffectedProjects);
+        }
+
+        [Fact]
+        public void IncrementalBuildResult_Constructor_ThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new IncrementalBuildResult(null));
+        }
+
+        [Fact]
+        public void FullSolutionBuildResult_Constructor_ValidatesInput()
+        {
+            var solutionPath = "MySolution.sln";
+            var result = new FullSolutionBuildResult(solutionPath);
+            Assert.Equal(solutionPath, result.SolutionPath);
+        }
+
+        [Fact]
+        public void FullSolutionBuildResult_Constructor_ThrowsOnNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FullSolutionBuildResult(null));
+        }
+    }
+} 

--- a/src/Incrementalist.Tests/Commands/RunDotNetCommandTaskTests.cs
+++ b/src/Incrementalist.Tests/Commands/RunDotNetCommandTaskTests.cs
@@ -117,7 +117,21 @@ namespace Incrementalist.Tests.Commands
             // Arrange
             var settings = new BuildSettings("master", "test.sln", _repository.BasePath);
             var solutionPath = Path.Combine(_repository.BasePath, "test.sln");
-            File.WriteAllText(solutionPath, ""); // Empty solution file for testing
+            
+            // Create a minimal valid solution file
+            var solutionContent = @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+EndGlobal";
+            File.WriteAllText(solutionPath, solutionContent);
+            
             var task = new RunDotNetCommandTask(settings, _logger, new[] { "build", "-c", "Release", "--nologo" }, true, false);
 
             // Act

--- a/src/Incrementalist.Tests/Commands/RunDotNetCommandTaskTests.cs
+++ b/src/Incrementalist.Tests/Commands/RunDotNetCommandTaskTests.cs
@@ -50,7 +50,7 @@ namespace Incrementalist.Tests.Commands
             var task = new RunDotNetCommandTask(settings, _logger, new[] { "build", "-c", "Release", "--nologo" }, true, false);
 
             // Act
-            var result = await task.Run(new[] { projectPath });
+            var result = await task.Run(new IncrementalBuildResult(new[] { projectPath }));
 
             // Assert
             result.Should().Be(0);
@@ -64,7 +64,7 @@ namespace Incrementalist.Tests.Commands
             var task = new RunDotNetCommandTask(settings, _logger, new[] { "build", "--invalid-option" }, true, false);
 
             // Act
-            var result = await task.Run(new[] { "dummy.csproj" });
+            var result = await task.Run(new IncrementalBuildResult(new[] { "dummy.csproj" }));
 
             // Assert
             result.Should().Be(1);
@@ -90,7 +90,7 @@ namespace Incrementalist.Tests.Commands
             var task = new RunDotNetCommandTask(settings, _logger, new[] { "build", "-c", "Release", "--nologo" }, true, true);
 
             // Act
-            var result = await task.Run(projects);
+            var result = await task.Run(new IncrementalBuildResult(projects));
 
             // Assert
             result.Should().Be(0);
@@ -105,10 +105,26 @@ namespace Incrementalist.Tests.Commands
             var projects = new[] { "project1.csproj", "project2.csproj" };
 
             // Act
-            var result = await task.Run(projects);
+            var result = await task.Run(new IncrementalBuildResult(projects));
 
             // Assert
             result.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task Should_Execute_Full_Solution_Build()
+        {
+            // Arrange
+            var settings = new BuildSettings("master", "test.sln", _repository.BasePath);
+            var solutionPath = Path.Combine(_repository.BasePath, "test.sln");
+            File.WriteAllText(solutionPath, ""); // Empty solution file for testing
+            var task = new RunDotNetCommandTask(settings, _logger, new[] { "build", "-c", "Release", "--nologo" }, true, false);
+
+            // Act
+            var result = await task.Run(new FullSolutionBuildResult(solutionPath));
+
+            // Assert
+            result.Should().Be(0);
         }
     }
 } 

--- a/src/Incrementalist.Tests/Dependencies/FSharpProjectsTrackingSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/FSharpProjectsTrackingSpecs.cs
@@ -55,9 +55,12 @@ namespace Incrementalist.Tests.Dependencies
             var settings = new BuildSettings("master", solutionFullPath, Repository.BasePath);
             var workspace = SetupMsBuildWorkspace();
             var emitTask = new EmitDependencyGraphTask(settings, workspace, logger);
-            var affectedFiles = (await emitTask.Run()).ToList();
+            var buildResult = await emitTask.Run();
 
-            affectedFiles.Select(f => f.Key).Should().HaveCount(2).And.Subject.Should().BeEquivalentTo(fsharpProjectFullPath, csharpProjectFullPath);
+            // When all projects are affected, we expect a full solution build
+            buildResult.Should().BeOfType<FullSolutionBuildResult>();
+            var fullBuildResult = (FullSolutionBuildResult)buildResult;
+            fullBuildResult.SolutionPath.Should().Be(solutionFullPath);
         }
 
         private static MSBuildWorkspace SetupMsBuildWorkspace()

--- a/src/Incrementalist.Tests/Incrementalist.Tests.csproj
+++ b/src/Incrementalist.Tests/Incrementalist.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Incrementalist.Tests/SolutionWideChangeDetectorTests.cs
+++ b/src/Incrementalist.Tests/SolutionWideChangeDetectorTests.cs
@@ -5,17 +5,51 @@
 // -----------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Incrementalist.ProjectSystem;
+using Incrementalist.Tests.Helpers;
+using Microsoft.CodeAnalysis;
 using Xunit;
 
 namespace Incrementalist.Tests
 {
-    public class SolutionWideChangeDetectorTests
+    public class SolutionWideChangeDetectorTests : IDisposable
     {
+        private readonly DisposableRepository _repository;
         private readonly SolutionWideChangeDetector _detector;
+        private readonly Solution _solution;
 
         public SolutionWideChangeDetectorTests()
         {
-            _detector = new SolutionWideChangeDetector();
+            _repository = new DisposableRepository();
+            
+            // Create a sample solution with project imports
+            var sample = ProjectSampleGenerator.GetProjectWithImportSample("TestProject.csproj");
+            
+            // Write files to the repository
+            _repository.WriteFile(sample.ProjectFile);
+            _repository.WriteFile(sample.ImportedPropsFile);
+            
+            // Create a solution file
+            var solutionPath = Path.Combine(_repository.BasePath, "test.sln");
+            File.WriteAllText(solutionPath, ""); // Empty solution file is sufficient for our tests
+            
+            // Create some solution-wide files
+            File.WriteAllText(Path.Combine(_repository.BasePath, "Directory.Build.props"), "<Project />");
+            File.WriteAllText(Path.Combine(_repository.BasePath, "Directory.Packages.props"), "<Project />");
+            
+            // Load the solution
+            var workspace = new AdhocWorkspace();
+            var solutionInfo = SolutionInfo.Create(
+                SolutionId.CreateNewId(),
+                VersionStamp.Create(),
+                solutionPath);
+            
+            _solution = workspace.AddSolution(solutionInfo);
+            _detector = new SolutionWideChangeDetector(_solution);
         }
 
         [Theory]
@@ -32,10 +66,8 @@ namespace Incrementalist.Tests
 
         [Theory]
         [InlineData("MySolution.sln")]
-        [InlineData("Common.props")]
-        [InlineData("Build.targets")]
         [InlineData("some/path/MySolution.sln")]
-        public void ExtensionMatch_SolutionWideFiles_ReturnsTrue(string fileName)
+        public void SolutionFile_ReturnsTrue(string fileName)
         {
             var changes = new[] { fileName };
             Assert.True(_detector.RequiresFullSolutionBuild(changes));
@@ -81,12 +113,15 @@ namespace Incrementalist.Tests
 
         [Theory]
         [InlineData("test.SLN")]
-        [InlineData("test.PROPS")]
-        [InlineData("test.TARGETS")]
         public void ExtensionMatching_IsCaseInsensitive(string fileName)
         {
             var changes = new[] { fileName };
             Assert.True(_detector.RequiresFullSolutionBuild(changes));
+        }
+
+        public void Dispose()
+        {
+            _repository?.Dispose();
         }
     }
 } 

--- a/src/Incrementalist.Tests/SolutionWideChangeDetectorTests.cs
+++ b/src/Incrementalist.Tests/SolutionWideChangeDetectorTests.cs
@@ -1,0 +1,92 @@
+// -----------------------------------------------------------------------
+// <copyright file="SolutionWideChangeDetectorTests.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Incrementalist.Tests
+{
+    public class SolutionWideChangeDetectorTests
+    {
+        private readonly SolutionWideChangeDetector _detector;
+
+        public SolutionWideChangeDetectorTests()
+        {
+            _detector = new SolutionWideChangeDetector();
+        }
+
+        [Theory]
+        [InlineData("Directory.Build.props")]
+        [InlineData("Directory.Packages.props")]
+        [InlineData("global.json")]
+        [InlineData("nuget.config")]
+        [InlineData("some/path/Directory.Build.props")]
+        public void DirectMatch_SolutionWideFiles_ReturnsTrue(string fileName)
+        {
+            var changes = new[] { fileName };
+            Assert.True(_detector.RequiresFullSolutionBuild(changes));
+        }
+
+        [Theory]
+        [InlineData("MySolution.sln")]
+        [InlineData("Common.props")]
+        [InlineData("Build.targets")]
+        [InlineData("some/path/MySolution.sln")]
+        public void ExtensionMatch_SolutionWideFiles_ReturnsTrue(string fileName)
+        {
+            var changes = new[] { fileName };
+            Assert.True(_detector.RequiresFullSolutionBuild(changes));
+        }
+
+        [Theory]
+        [InlineData("src/Project1/Project1.csproj")]
+        [InlineData("src/Project1/Class1.cs")]
+        [InlineData("README.md")]
+        public void NonSolutionWideFiles_ReturnsFalse(string fileName)
+        {
+            var changes = new[] { fileName };
+            Assert.False(_detector.RequiresFullSolutionBuild(changes));
+        }
+
+        [Fact]
+        public void MultipleChanges_WithOneSolutionWideFile_ReturnsTrue()
+        {
+            var changes = new[]
+            {
+                "src/Project1/Class1.cs",
+                "Directory.Build.props",
+                "src/Project2/Class2.cs"
+            };
+            Assert.True(_detector.RequiresFullSolutionBuild(changes));
+        }
+
+        [Fact]
+        public void NullChanges_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => _detector.RequiresFullSolutionBuild(null));
+        }
+
+        [Theory]
+        [InlineData("DIRECTORY.BUILD.PROPS")]
+        [InlineData("directory.build.props")]
+        [InlineData("DiReCtOrY.bUiLd.PrOpS")]
+        public void FileNameMatching_IsCaseInsensitive(string fileName)
+        {
+            var changes = new[] { fileName };
+            Assert.True(_detector.RequiresFullSolutionBuild(changes));
+        }
+
+        [Theory]
+        [InlineData("test.SLN")]
+        [InlineData("test.PROPS")]
+        [InlineData("test.TARGETS")]
+        public void ExtensionMatching_IsCaseInsensitive(string fileName)
+        {
+            var changes = new[] { fileName };
+            Assert.True(_detector.RequiresFullSolutionBuild(changes));
+        }
+    }
+} 

--- a/src/Incrementalist/BuildAnalysisResult.cs
+++ b/src/Incrementalist/BuildAnalysisResult.cs
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+// <copyright file="BuildAnalysisResult.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Incrementalist
+{
+    /// <summary>
+    /// Base class for representing the result of analyzing which parts of the solution need to be built.
+    /// </summary>
+    public abstract class BuildAnalysisResult
+    {
+        // Base class for our union type
+    }
+
+    /// <summary>
+    /// Represents a result where only specific projects need to be built.
+    /// </summary>
+    public sealed class IncrementalBuildResult : BuildAnalysisResult 
+    {
+        public IncrementalBuildResult(IReadOnlyList<string> affectedProjects)
+        {
+            AffectedProjects = affectedProjects ?? throw new ArgumentNullException(nameof(affectedProjects));
+        }
+
+        /// <summary>
+        /// The list of projects that need to be built.
+        /// </summary>
+        public IReadOnlyList<string> AffectedProjects { get; }
+    }
+
+    /// <summary>
+    /// Represents a result where the entire solution needs to be built.
+    /// </summary>
+    public sealed class FullSolutionBuildResult : BuildAnalysisResult 
+    {
+        public FullSolutionBuildResult(string solutionPath)
+        {
+            SolutionPath = solutionPath ?? throw new ArgumentNullException(nameof(solutionPath));
+        }
+
+        /// <summary>
+        /// The path to the solution file that needs to be built.
+        /// </summary>
+        public string SolutionPath { get; }
+    }
+} 

--- a/src/Incrementalist/BuildAnalysisResult.cs
+++ b/src/Incrementalist/BuildAnalysisResult.cs
@@ -6,6 +6,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
 
 namespace Incrementalist
 {
@@ -14,7 +16,6 @@ namespace Incrementalist
     /// </summary>
     public abstract class BuildAnalysisResult
     {
-        // Base class for our union type
     }
 
     /// <summary>

--- a/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
@@ -37,8 +37,7 @@ namespace Incrementalist.ProjectSystem.Cmds
             Task<Dictionary<string, SlnFile>> previousTask)
         {
             var fileDictObj = await previousTask;
-
-            var fileDict = (Dictionary<string, SlnFile>) fileDictObj;
+            var fileDict = (Dictionary<string, SlnFile>)fileDictObj;
 
             var repoResult = GitRunner.FindRepository(_workingDirectory);
             if (!repoResult.foundRepo)

--- a/src/Incrementalist/SolutionWideChangeDetector.cs
+++ b/src/Incrementalist/SolutionWideChangeDetector.cs
@@ -1,0 +1,53 @@
+// -----------------------------------------------------------------------
+// <copyright file="SolutionWideChangeDetector.cs" company="Petabridge, LLC">
+//      Copyright (C) 2015 - 2024 Petabridge, LLC <https://petabridge.com>
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Incrementalist
+{
+    /// <summary>
+    /// Detects changes that would require a full solution build rather than an incremental build.
+    /// </summary>
+    public sealed class SolutionWideChangeDetector
+    {
+        private static readonly HashSet<string> SolutionWideFileNames = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Directory.Build.props",
+            "Directory.Packages.props",
+            "global.json",
+            "nuget.config"
+        };
+
+        private static readonly HashSet<string> SolutionWideExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".sln",
+            ".props",
+            ".targets"
+        };
+
+        /// <summary>
+        /// Determines if any of the changed files would require a full solution build.
+        /// </summary>
+        /// <param name="changedFiles">The list of files that have changed.</param>
+        /// <returns>True if a full solution build is required, false otherwise.</returns>
+        public bool RequiresFullSolutionBuild(IEnumerable<string> changedFiles)
+        {
+            if (changedFiles == null) throw new ArgumentNullException(nameof(changedFiles));
+
+            return changedFiles.Any(file =>
+            {
+                var fileName = Path.GetFileName(file);
+                var extension = Path.GetExtension(file);
+
+                return SolutionWideFileNames.Contains(fileName) || 
+                       SolutionWideExtensions.Contains(extension);
+            });
+        }
+    }
+} 

--- a/src/Incrementalist/SolutionWideChangeDetector.cs
+++ b/src/Incrementalist/SolutionWideChangeDetector.cs
@@ -8,6 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Incrementalist.ProjectSystem;
+using Microsoft.CodeAnalysis;
 
 namespace Incrementalist
 {
@@ -16,7 +18,7 @@ namespace Incrementalist
     /// </summary>
     public sealed class SolutionWideChangeDetector
     {
-        private static readonly HashSet<string> SolutionWideFileNames = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> AlwaysSolutionWideFiles = new(StringComparer.OrdinalIgnoreCase)
         {
             "Directory.Build.props",
             "Directory.Packages.props",
@@ -24,12 +26,34 @@ namespace Incrementalist
             "nuget.config"
         };
 
-        private static readonly HashSet<string> SolutionWideExtensions = new(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> AlwaysSolutionWideExtensions = new(StringComparer.OrdinalIgnoreCase)
         {
-            ".sln",
-            ".props",
-            ".targets"
+            ".sln"
         };
+
+        private readonly IReadOnlyDictionary<string, ImportedFile> _projectImports;
+
+        /// <summary>
+        /// Creates a new instance of the SolutionWideChangeDetector using a Solution object.
+        /// </summary>
+        public SolutionWideChangeDetector(Solution solution)
+        {
+            if (solution == null) throw new ArgumentNullException(nameof(solution));
+            
+            var projectFiles = solution.Projects
+                .Select(p => new SlnFileWithPath(p.FilePath, new SlnFile(FileType.Project, p.Id)))
+                .ToList();
+            
+            _projectImports = ProjectImportsFinder.FindProjectImports(projectFiles);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the SolutionWideChangeDetector using pre-computed project imports.
+        /// </summary>
+        public SolutionWideChangeDetector(IReadOnlyDictionary<string, ImportedFile> projectImports)
+        {
+            _projectImports = projectImports ?? throw new ArgumentNullException(nameof(projectImports));
+        }
 
         /// <summary>
         /// Determines if any of the changed files would require a full solution build.
@@ -40,14 +64,69 @@ namespace Incrementalist
         {
             if (changedFiles == null) throw new ArgumentNullException(nameof(changedFiles));
 
-            return changedFiles.Any(file =>
+            foreach(var file in changedFiles)
             {
-                var fileName = Path.GetFileName(file);
-                var extension = Path.GetExtension(file);
+                if (IsSolutionWideFile(file))
+                    return true;
 
-                return SolutionWideFileNames.Contains(fileName) || 
-                       SolutionWideExtensions.Contains(extension);
-            });
+                // If it's a .props or .targets file, check if it affects multiple projects
+                if (_projectImports.TryGetValue(file, out var importedFile))
+                {
+                    if (IsWidelyImportedFile(importedFile))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines if a file is considered solution-wide based on its name or extension.
+        /// </summary>
+        internal static bool IsSolutionWideFile(string filePath)
+        {
+            var fileName = Path.GetFileName(filePath);
+            var extension = Path.GetExtension(filePath);
+
+            return AlwaysSolutionWideFiles.Contains(fileName) || 
+                   AlwaysSolutionWideExtensions.Contains(extension);
+        }
+
+        /// <summary>
+        /// Determines if an imported file affects multiple projects or is imported by Directory.Build.props.
+        /// </summary>
+        internal static bool IsWidelyImportedFile(ImportedFile importedFile)
+        {
+            // If this props/targets file is imported by Directory.Build.props or affects multiple projects,
+            // we should do a full solution build
+            var isImportedByDirectoryBuildProps = importedFile.DependantProjects
+                .Any(p => Path.GetFileName(p.Path).Equals("Directory.Build.props", StringComparison.OrdinalIgnoreCase));
+            
+            var affectsMultipleProjects = importedFile.DependantProjects.Count > 1;
+
+            return isImportedByDirectoryBuildProps || affectsMultipleProjects;
+        }
+
+        /// <summary>
+        /// Creates the appropriate BuildAnalysisResult based on whether all projects in the solution are affected.
+        /// </summary>
+        /// <param name="solution">The solution being analyzed.</param>
+        /// <param name="affectedProjects">The list of affected project paths.</param>
+        /// <returns>A FullSolutionBuildResult if all projects are affected, otherwise an IncrementalBuildResult.</returns>
+        public static BuildAnalysisResult CreateBuildResult(Solution solution, IReadOnlyList<string> affectedProjects)
+        {
+            if (solution == null) throw new ArgumentNullException(nameof(solution));
+            if (affectedProjects == null) throw new ArgumentNullException(nameof(affectedProjects));
+
+            var totalProjects = solution.Projects.Count();
+            
+            // If all projects are affected, return a full solution build result
+            if (affectedProjects.Count == totalProjects)
+            {
+                return new FullSolutionBuildResult(solution.FilePath);
+            }
+
+            return new IncrementalBuildResult(affectedProjects);
         }
     }
 } 


### PR DESCRIPTION
close https://github.com/petabridge/Incrementalist/issues/235

In the event that some "global" files are modified, we should just run all of the commands passed to Incrementalist directly against the solution instead.