### PR TITLE
Better `dotnet` shell output logging

### DIFF
--- a/src/Incrementalist.Cmd/Commands/RunDotNetCommandTask.cs
+++ b/src/Incrementalist.Cmd/Commands/RunDotNetCommandTask.cs
@@ -110,36 +110,22 @@ namespace Incrementalist.Cmd.Commands
             if (!args.Contains("--project") && !args.Contains("-p"))
                 args = $"{args} \"{target}\"";
 
+            _logger.LogInformation("Executing 'dotnet {0}' for {1}", args, target);
+
             var process = new Process
             {
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = "dotnet",
                     Arguments = args,
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
+                    UseShellExecute = true,
                     WorkingDirectory = _settings.WorkingDirectory
                 }
-            };
-
-            process.OutputDataReceived += (sender, eventArgs) =>
-            {
-                if (!string.IsNullOrEmpty(eventArgs.Data))
-                    _logger.LogInformation("[{0}] {1}", target, eventArgs.Data);
-            };
-
-            process.ErrorDataReceived += (sender, eventArgs) =>
-            {
-                if (!string.IsNullOrEmpty(eventArgs.Data))
-                    _logger.LogError("[{0}] {1}", target, eventArgs.Data);
             };
 
             try
             {
                 process.Start();
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
                 await process.WaitForExitAsync();
                 
                 if (process.ExitCode != 0)

--- a/src/Incrementalist.Cmd/Commands/RunDotNetCommandTask.cs
+++ b/src/Incrementalist.Cmd/Commands/RunDotNetCommandTask.cs
@@ -118,14 +118,32 @@ namespace Incrementalist.Cmd.Commands
                 {
                     FileName = "dotnet",
                     Arguments = args,
-                    UseShellExecute = true,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true,
                     WorkingDirectory = _settings.WorkingDirectory
                 }
             };
 
-            try
+            // Redirect to console streams directly
+            process.OutputDataReceived += (_, e) =>
             {
+                if (!string.IsNullOrEmpty(e.Data))
+                    Console.Out.WriteLine(e.Data);
+            };
+
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                    Console.Error.WriteLine(e.Data);
+            };
+
+            try
+            {                
                 process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
                 await process.WaitForExitAsync();
                 
                 if (process.ExitCode != 0)


### PR DESCRIPTION
Write the `dotnet` stderr and stdout directly to the console without going through the `ILogger` on Incrementalist