### PR TITLE
Add more robust quoting for `dotnet` commands

### DIFF
--- a/src/Incrementalist.Cmd/Commands/CommandLineArgumentParser.cs
+++ b/src/Incrementalist.Cmd/Commands/CommandLineArgumentParser.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Incrementalist.Cmd.Commands
+{
+    /// <summary>
+    /// Handles parsing of complex command line arguments with proper quote handling
+    /// </summary>
+    public static class CommandLineArgumentParser
+    {
+        /// <summary>
+        /// Combines command line arguments into a properly quoted string
+        /// </summary>
+        public static string CombineArguments(IEnumerable<string> arguments)
+        {
+            if (arguments == null) throw new ArgumentNullException(nameof(arguments));
+            
+            var sb = new StringBuilder();
+            foreach (var arg in arguments)
+            {
+                if (sb.Length > 0)
+                    sb.Append(' ');
+
+                // Check if we need to quote this argument
+                var needsQuoting = arg.Contains(' ') || arg.Contains('\t') || arg.Contains('"');
+                
+                if (!needsQuoting)
+                {
+                    sb.Append(arg);
+                }
+                else
+                {
+                    sb.Append('"');
+                    
+                    // Replace any embedded quotes with escaped quotes
+                    sb.Append(arg.Replace("\"", "\\\""));
+                    
+                    sb.Append('"');
+                }
+            }
+            
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Splits a command line string into individual arguments, preserving quoted sections
+        /// </summary>
+        public static string[] SplitArguments(string commandLine)
+        {
+            if (string.IsNullOrEmpty(commandLine)) return Array.Empty<string>();
+
+            var args = new List<string>();
+            var currentArg = new StringBuilder();
+            var inQuotes = false;
+            var escaped = false;
+
+            for (var i = 0; i < commandLine.Length; i++)
+            {
+                var c = commandLine[i];
+
+                if (escaped)
+                {
+                    currentArg.Append(c);
+                    escaped = false;
+                    continue;
+                }
+
+                if (c == '\\')
+                {
+                    escaped = true;
+                    continue;
+                }
+
+                if (c == '"')
+                {
+                    inQuotes = !inQuotes;
+                    continue;
+                }
+
+                if (!inQuotes && char.IsWhiteSpace(c))
+                {
+                    if (currentArg.Length > 0)
+                    {
+                        args.Add(currentArg.ToString());
+                        currentArg.Clear();
+                    }
+                    continue;
+                }
+
+                currentArg.Append(c);
+            }
+
+            if (currentArg.Length > 0)
+                args.Add(currentArg.ToString());
+
+            return args.ToArray();
+        }
+    }
+} 

--- a/src/Incrementalist.Cmd/Commands/RunDotNetCommandTask.cs
+++ b/src/Incrementalist.Cmd/Commands/RunDotNetCommandTask.cs
@@ -106,7 +106,7 @@ namespace Incrementalist.Cmd.Commands
         private async Task<int> RunCommand(string target)
         {
             // For dotnet CLI commands like 'build', 'test', etc., the project/solution path comes last
-            var args = string.Join(" ", _dotnetArgs);
+            var args = CommandLineArgumentParser.CombineArguments(_dotnetArgs);
             if (!args.Contains("--project") && !args.Contains("-p"))
                 args = $"{args} \"{target}\"";
 

--- a/src/Incrementalist.Cmd/Program.cs
+++ b/src/Incrementalist.Cmd/Program.cs
@@ -49,9 +49,11 @@ namespace Incrementalist.Cmd
             SetTitle();
 
             // Split args at -- to separate incrementalist args from dotnet args
-            var splitIndex = Array.IndexOf(args, "--");
-            var incrementalistArgs = splitIndex >= 0 ? args.Take(splitIndex).ToArray() : args;
-            var dotnetArgs = splitIndex >= 0 ? args.Skip(splitIndex + 1).ToArray() : [];
+            var allArgs = string.Join(" ", args);
+            var parts = allArgs.Split(new[] { " -- " }, StringSplitOptions.None);
+            
+            var incrementalistArgs = parts.Length > 0 ? CommandLineArgumentParser.SplitArguments(parts[0]) : Array.Empty<string>();
+            var dotnetArgs = parts.Length > 1 ? CommandLineArgumentParser.SplitArguments(parts[1]) : Array.Empty<string>();
 
             SlnOptions options = null;
             var result = Parser.Default.ParseArguments<SlnOptions>(incrementalistArgs).MapResult(r =>

--- a/src/Incrementalist.Cmd/Program.cs
+++ b/src/Incrementalist.Cmd/Program.cs
@@ -51,7 +51,7 @@ namespace Incrementalist.Cmd
             // Split args at -- to separate incrementalist args from dotnet args
             var splitIndex = Array.IndexOf(args, "--");
             var incrementalistArgs = splitIndex >= 0 ? args.Take(splitIndex).ToArray() : args;
-            var dotnetArgs = splitIndex >= 0 ? args.Skip(splitIndex + 1).ToArray() : Array.Empty<string>();
+            var dotnetArgs = splitIndex >= 0 ? args.Skip(splitIndex + 1).ToArray() : [];
 
             SlnOptions options = null;
             var result = Parser.Default.ParseArguments<SlnOptions>(incrementalistArgs).MapResult(r =>
@@ -116,10 +116,10 @@ namespace Incrementalist.Cmd
                     if (!DiffHelper.HasBranch(repoResult.repo, options.GitBranch))
                     {
                         logger.LogError("Current git repository doesn't have any branch named [{0}]. Shutting down.", options.GitBranch);
-                        logger.LogDebug("Here are all of the currently known branches in this repository:");
+                        logger.LogInformation("Here are all of the currently known branches in this repository:");
                         foreach (var b in repoResult.repo.Branches)
                         {
-                            logger.LogDebug(b.FriendlyName);
+                            logger.LogInformation(b.FriendlyName);
                         }
 
                         return -4;
@@ -131,7 +131,7 @@ namespace Incrementalist.Cmd
                     if (options.ListFolders)
                         await AnalyzeFolderDiff(options, workingFolder, logger);
                     else
-                        await AnaylzeSolutionDIff(options, workingFolder, logger);
+                        await AnalyzeSolutionDIff(options, workingFolder, logger);
                 }
 
                 return 0;
@@ -158,7 +158,7 @@ namespace Incrementalist.Cmd
             HandleAffectedFiles(options, affectedFilesStr, affectedFiles.Count, logger);
         }
 
-        private static async Task AnaylzeSolutionDIff(SlnOptions options, DirectoryInfo workingFolder, ILogger logger)
+        private static async Task AnalyzeSolutionDIff(SlnOptions options, DirectoryInfo workingFolder, ILogger logger)
         {
             // Locate and register the default instance of MSBuild installed on this machine.
             MSBuildLocator.RegisterDefaults();

--- a/src/Incrementalist.Tests/CommandLineArgumentParserTests.cs
+++ b/src/Incrementalist.Tests/CommandLineArgumentParserTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using Incrementalist.Cmd.Commands;
+using Xunit;
+
+namespace Incrementalist.Tests
+{
+    public class CommandLineArgumentParserTests
+    {
+        [Fact]
+        public void CombineArguments_WithSimpleArgs_ShouldNotQuote()
+        {
+            var args = new[] { "test", "-c", "Release", "--no-build" };
+            var result = CommandLineArgumentParser.CombineArguments(args);
+            Assert.Equal("test -c Release --no-build", result);
+        }
+
+        [Fact]
+        public void CombineArguments_WithSpaces_ShouldQuote()
+        {
+            var args = new[] { "test", "--collect:\"XPlat Code Coverage\"", "--logger:\"console;verbosity=normal\"" };
+            var result = CommandLineArgumentParser.CombineArguments(args);
+            Assert.Equal("test \"--collect:\\\"XPlat Code Coverage\\\"\" \"--logger:\\\"console;verbosity=normal\\\"\"", result);
+        }
+
+        [Fact]
+        public void SplitArguments_WithQuotedSpaces_ShouldPreserveQuotes()
+        {
+            var input = "test -c Release --no-build \"--collect:XPlat Code Coverage\" \"--logger:console;verbosity=normal\"";
+            var result = CommandLineArgumentParser.SplitArguments(input);
+            
+            Assert.Equal(new[]
+            {
+                "test",
+                "-c",
+                "Release",
+                "--no-build",
+                "--collect:XPlat Code Coverage",
+                "--logger:console;verbosity=normal"
+            }, result);
+        }
+
+        [Fact]
+        public void SplitArguments_WithEscapedQuotes_ShouldHandleCorrectly()
+        {
+            var input = "test \"--logger:\\\"trx\\\"\" \"--collect:\\\"XPlat Code Coverage\\\"\"";
+            var result = CommandLineArgumentParser.SplitArguments(input);
+            
+            Assert.Equal(new[]
+            {
+                "test",
+                "--logger:\"trx\"",
+                "--collect:\"XPlat Code Coverage\""
+            }, result);
+        }
+
+        [Fact]
+        public void CombineAndSplit_ShouldBeSymmetric()
+        {
+            var originalArgs = new[]
+            {
+                "test",
+                "-c",
+                "Release",
+                "--no-build",
+                "--logger:\"trx\"",
+                "--collect:\"XPlat Code Coverage\"",
+                "--logger:\"console;verbosity=normal\"",
+                "--results-directory:TestResults"
+            };
+
+            var combined = CommandLineArgumentParser.CombineArguments(originalArgs);
+            var split = CommandLineArgumentParser.SplitArguments(combined);
+
+            Assert.Equal(originalArgs, split);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void SplitArguments_WithEmptyInput_ReturnsEmptyArray(string input)
+        {
+            var result = CommandLineArgumentParser.SplitArguments(input);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void CombineArguments_WithNull_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => CommandLineArgumentParser.CombineArguments(null));
+        }
+    }
+} 


### PR DESCRIPTION
We were having issues with complex CLI arguments such as:

```
        dotnet tool run incrementalist -- -b $TargetBranch -r -- test -c $Configuration --no-build `
            '--logger:trx' `
            '--collect:"XPlat Code Coverage"' `
            '--logger:"console;verbosity=normal"' `
            "--results-directory:$OutputTests"
```

Where the `XPlat Code Coverage` argument lost its quotes, somewhere, and resulted in MSBuild becoming unhappy. This PR should resolve that.