### PR TITLE
added v1.0.0-rc2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+#### 1.0.0-rc2 Apr 13 2025 ####
+
+Bug fixes and improvements:
+
+* Fixed issues with command-line parsing and configuration
+* Resolved globbing functionality for `dotnet` commands
+* Enhanced documentation with more examples
+
+All changes:
+
+* [Fix globbing for `dotnet` commands](https://github.com/petabridge/Incrementalist/pull/384)
+* [Resolve `--create-config` issues](https://github.com/petabridge/Incrementalist/pull/382)
+* [Resolve Option 'c, config' is defined multiple times](https://github.com/petabridge/Incrementalist/pull/379)
+* [Add globbing examples to config docs](https://github.com/petabridge/Incrementalist/pull/376)
+* [README: expand examples of configuration file support](https://github.com/petabridge/Incrementalist/pull/375)
+
 #### 1.0.0-rc1 Apr 13 2025 ####
 
 Added major new features to enhance usability and extend capabilities:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,28 +2,20 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-$([System.DateTime]::Now.Year) Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>1.0.0-rc1</VersionPrefix>
-    <PackageReleaseNotes>Added major new features to enhance usability and extend capabilities:
+    <VersionPrefix>1.0.0-rc2</VersionPrefix>
+    <PackageReleaseNotes>Bug fixes and improvements:
 
-* **File-based Configuration**: Added support for `.incrementalist.yml` configuration files. Store common settings and project filters in a single file rather than passing command-line arguments. Example: `incrementalist -c .incrementalist.yml` loads all settings from the file.
-
-* **File Globbing Support**: Added file globbing pattern support for command execution. Target files using glob patterns for selective builds or testing. Example: `incrementalist -b dev -r --glob "**/*.Tests.csproj" -- test` runs tests only on affected test projects.
-
-* **`.slnx` Support**: Added support for [modern Visual Studio solution files](https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/) (`.slnx`). Incrementalist now properly processes these files alongside standard `.sln` files, enabling better integration with Visual Studio's "Open Folder" feature.
+* Fixed issues with command-line parsing and configuration
+* Resolved globbing functionality for `dotnet` commands
+* Enhanced documentation with more examples
 
 All changes:
 
-* [Enable `Nullability` and `TreatWarningsAsErrors`](https://github.com/petabridge/Incrementalist/pull/372)
-* [Added support for file globbing commands](https://github.com/petabridge/Incrementalist/pull/371)
-* [Added `.slnx` support](https://github.com/petabridge/Incrementalist/pull/370)
-* [Solution cleanup](https://github.com/petabridge/Incrementalist/pull/369)
-* [Disable caching](https://github.com/petabridge/Incrementalist/pull/367)
-* [File-based configuration format](https://github.com/petabridge/Incrementalist/pull/357)
-* [Bump Microsoft.Extensions.Logging.Console from 9.0.3 to 9.0.4](https://github.com/petabridge/Incrementalist/pull/364)
-* [Bump Microsoft.Build.Locator from 1.7.8 to 1.9.1](https://github.com/petabridge/Incrementalist/pull/362)
-* [Bump Microsoft.Extensions.Logging from 9.0.2 to 9.0.3](https://github.com/petabridge/Incrementalist/pull/361)
-* [Bump Microsoft.Extensions.Logging.Console from 9.0.2 to 9.0.3](https://github.com/petabridge/Incrementalist/pull/360)
-* [Bump NuGet.ProjectModel from 6.13.1 to 6.13.2](https://github.com/petabridge/Incrementalist/pull/359)</PackageReleaseNotes>
+* [Fix globbing for `dotnet` commands](https://github.com/petabridge/Incrementalist/pull/384)
+* [Resolve `--create-config` issues](https://github.com/petabridge/Incrementalist/pull/382)
+* [Resolve Option 'c, config' is defined multiple times](https://github.com/petabridge/Incrementalist/pull/379)
+* [Add globbing examples to config docs](https://github.com/petabridge/Incrementalist/pull/376)
+* [README: expand examples of configuration file support](https://github.com/petabridge/Incrementalist/pull/375)</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIcon>incrementalist-logo-dark.png</PackageIcon>
     <PackageProjectUrl>


### PR DESCRIPTION
#### 1.0.0-rc2 Apr 13 2025 ####

Bug fixes and improvements:

* Fixed issues with command-line parsing and configuration
* Resolved globbing functionality for `dotnet` commands
* Enhanced documentation with more examples

All changes:

* [Fix globbing for `dotnet` commands](https://github.com/petabridge/Incrementalist/pull/384)
* [Resolve `--create-config` issues](https://github.com/petabridge/Incrementalist/pull/382)
* [Resolve Option 'c, config' is defined multiple times](https://github.com/petabridge/Incrementalist/pull/379)
* [Add globbing examples to config docs](https://github.com/petabridge/Incrementalist/pull/376)
* [README: expand examples of configuration file support](https://github.com/petabridge/Incrementalist/pull/375)