### PR TITLE
Spike comparing against a commit sha instead of branch head

### DIFF
--- a/src/Incrementalist.Cmd/Commands/EmitAffectedFoldersTask.cs
+++ b/src/Incrementalist.Cmd/Commands/EmitAffectedFoldersTask.cs
@@ -44,9 +44,9 @@ namespace Incrementalist.Cmd.Commands
             }
 
             // validate the target branch
-            if (!DiffHelper.HasBranch(repo, Settings.TargetBranch))
+            if (!DiffHelper.HasBranch(repo, Settings.TargetBranch) && !DiffHelper.HasCommit(repo, Settings.TargetBranch))
             {
-                Logger.LogError("Current git repository doesn't have any branch named [{BranchName}]. Shutting down.",
+                Logger.LogError("Current git repository doesn't have any branch or commit [{BranchName}]. Shutting down.",
                     Settings.TargetBranch);
                 return new Dictionary<AbsolutePath, ICollection<AbsolutePath>>();
             }

--- a/src/Incrementalist.Cmd/Config/ConfigMerger.cs
+++ b/src/Incrementalist.Cmd/Config/ConfigMerger.cs
@@ -37,6 +37,7 @@ namespace Incrementalist.Cmd.Config
             merged.OutputFile = options.OutputFile ?? config.OutputFile;
             merged.GitBranch = (options.GitBranch ?? config.GitBranch) ?? "dev";
             merged.WorkingDirectory = options.WorkingDirectory ?? config.WorkingDirectory;
+            merged.CompareSha = options.CompareSha; // Not useful to set CompareSha in config
 
             // Merge bool properties (CLI takes precedence)
             merged.Verbose = config.Verbose.GetValueOrDefault(false);

--- a/src/Incrementalist.Cmd/Program.cs
+++ b/src/Incrementalist.Cmd/Program.cs
@@ -147,8 +147,17 @@ namespace Incrementalist.Cmd
                     return -3;
                 }
 
-                // validate the target branch
-                if (!DiffHelper.HasBranch(repo, cmdOptions.GitBranch!))
+                // validate the target branch or commit SHA
+                if (!string.IsNullOrEmpty(cmdOptions.CompareSha))
+                {
+                    if (!DiffHelper.HasCommit(repo, cmdOptions.CompareSha))
+                    {
+                        logger.LogError("The specified commit SHA [{CommitSha}] does not exist in the repository. Shutting down.",
+                            cmdOptions.CompareSha);
+                        return -5;
+                    }
+                }
+                else if (!DiffHelper.HasBranch(repo, cmdOptions.GitBranch!))
                 {
                     // workaround common CI server issues and check to see if this same branch is located
                     // under "origin/{branchname}"
@@ -204,7 +213,7 @@ namespace Incrementalist.Cmd
                 ? workingFolder.ComputeRelativePathToMe(new AbsolutePath(Path.GetFullPath(options.SolutionFilePath)))
                 : RelativePath.Empty;
 
-            var settings = new BuildSettings(options.GitBranch!, normalized,
+            var settings = new BuildSettings(options.CompareTarget!, normalized,
                 workingFolder,
                 options.SkipGlobs?.ToArray() ?? [],
                 options.TargetGlobs?.ToArray() ?? [],
@@ -244,7 +253,7 @@ namespace Incrementalist.Cmd
 
             logger.LogInformation("Starting analysis of solution: {Solution}", sln);
 
-            var settings = new BuildSettings(options.GitBranch!, sln, workingFolder,
+            var settings = new BuildSettings(options.CompareTarget!, sln, workingFolder,
                 options.SkipGlobs?.ToArray() ?? [],
                 options.TargetGlobs?.ToArray() ?? [],
                 TimeSpan.FromMinutes(options.TimeoutMinutes));

--- a/src/Incrementalist.Cmd/SlnOptions.cs
+++ b/src/Incrementalist.Cmd/SlnOptions.cs
@@ -70,6 +70,11 @@ namespace Incrementalist.Cmd
             Required = false)]
         public string? GitBranch { get; set; }
 
+        [Option("compare-sha", 
+            HelpText = "Specify a commit SHA to compare against instead of a branch. If both --branch and --compare-sha are provided, --compare-sha takes precedence.", 
+            Required = false)]
+        public string? CompareSha { get; set; }
+
         [Option('d', "dir",
             HelpText = "Specify the working directory explicitly. Defaults to using the current working directory.")]
         public string? WorkingDirectory { get; set; }
@@ -114,6 +119,11 @@ namespace Incrementalist.Cmd
                 "Glob pattern to include only matching projects in the final list. Applied after analyzing dependencies.",
             Required = false)]
         public IEnumerable<string>? TargetGlobs { get; set; }
+
+        /// <summary>
+        /// Returns the target for comparison, prioritizing CompareSha over GitBranch.
+        /// </summary>
+        public string? CompareTarget => !string.IsNullOrEmpty(CompareSha) ? CompareSha : GitBranch;
 
         /// <summary>
         /// Needed for configuration merging.

--- a/src/Incrementalist.Tests/Git/GitDiffDetectionSpecs.cs
+++ b/src/Incrementalist.Tests/Git/GitDiffDetectionSpecs.cs
@@ -114,5 +114,19 @@ namespace Incrementalist.Tests.Git
             Assert.Equal("fuber.txt", Path.GetFileName(file.Path));
             Assert.Equal(Path.GetFullPath("fuber.txt", Repository.BasePath.Path), file.Path);
         }
+
+        [Fact(DisplayName = "Should detect changes when comparing against a commit SHA")]
+        public void Should_detect_changes_against_commit_sha()
+        {
+            var initialCommit = Repository.WriteFile("file1.txt", "content1")
+                .Commit("Initial commit");
+
+            Repository.WriteFile("file2.txt", "content2")
+                .Commit("Second commit");
+
+            var diffedFiles = DiffHelper.ChangedFiles(Repository.Repository, initialCommit.Repository.Head.Tip.Sha).ToList();
+            Assert.Single(diffedFiles);
+            Assert.Equal("file2.txt", Path.GetFileName(diffedFiles[0].Path));
+        }
     }
 }

--- a/src/Incrementalist.Tests/Git/GitDiffDetectionSpecs.cs
+++ b/src/Incrementalist.Tests/Git/GitDiffDetectionSpecs.cs
@@ -119,12 +119,12 @@ namespace Incrementalist.Tests.Git
         public void Should_detect_changes_against_commit_sha()
         {
             var initialCommit = Repository.WriteFile("file1.txt", "content1")
-                .Commit("Initial commit");
+                .Commit("Initial commit").Repository.Head.Tip.Sha;
 
             Repository.WriteFile("file2.txt", "content2")
                 .Commit("Second commit");
 
-            var diffedFiles = DiffHelper.ChangedFiles(Repository.Repository, initialCommit.Repository.Head.Tip.Sha).ToList();
+            var diffedFiles = DiffHelper.ChangedFiles(Repository.Repository, initialCommit).ToList();
             Assert.Single(diffedFiles);
             Assert.Equal("file2.txt", Path.GetFileName(diffedFiles[0].Path));
         }

--- a/src/Incrementalist.Tests/SlnOptionsTests.cs
+++ b/src/Incrementalist.Tests/SlnOptionsTests.cs
@@ -1,0 +1,52 @@
+using Incrementalist.Cmd;
+using Xunit;
+
+public class SlnOptionsTests
+{
+
+    [Fact]
+    public void CompareTarget_Should_Return_CommitSha_When_Provided()
+    {
+        // Arrange
+        var options = new RunOptions
+        {
+            CompareSha = "abc123",
+            GitBranch = "main"
+        };
+
+        // Act
+        var target = options.CompareTarget;
+
+        // Assert
+        Assert.Equal("abc123", target);
+    }
+
+    [Fact]
+    public void CompareTarget_Should_Return_GitBranch_When_CommitSha_Is_Null()
+    {
+        // Arrange
+        var options = new RunOptions
+        {
+            GitBranch = "main"
+        };
+
+        // Act
+        var target = options.CompareTarget;
+
+        // Assert
+        Assert.Equal("main", target);
+    }
+
+    [Fact]
+    public void CompareTarget_Should_Return_Null_When_Both_Are_Null()
+    {
+        // Arrange
+        var options = new RunOptions();
+
+        // Act
+        var target = options.CompareTarget;
+
+        // Assert
+        Assert.Null(target);
+    }
+}

--- a/src/Incrementalist/Git/DiffHelper.cs
+++ b/src/Incrementalist/Git/DiffHelper.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,9 +17,21 @@ namespace Incrementalist.Git
     /// </summary>
     public static class DiffHelper
     {
-        public static IEnumerable<AbsolutePath> ChangedFiles(Repository repo, string targetBranch)
+        public static IEnumerable<AbsolutePath> ChangedFiles(Repository repo, string targetBranchOrCommit)
         {
-            var targetTree = repo.Branches[targetBranch].Tip.Tree;
+            // Use indexer to utilize name resolution
+            var targetTree = repo.Branches[targetBranchOrCommit]?.Tip.Tree;
+
+            if(targetTree == null)
+            {
+                targetTree = repo.Lookup<Commit>(targetBranchOrCommit)?.Tree;
+            }
+
+            if(targetTree == null)
+            {
+                throw new ArgumentException($"Target branch or commit [{targetBranchOrCommit}] not found.");
+            }
+
             var changes = new HashSet<AbsolutePath>();
 
             // Get all changes between target branch and current state (including both staged and unstaged)
@@ -51,6 +64,11 @@ namespace Incrementalist.Git
         public static bool HasBranch(Repository repo, string targetBranch)
         {
             return repo.Branches.Any(x => x.FriendlyName.Equals(targetBranch));
+        }
+
+        public static bool HasCommit(Repository repo, string commitSha)
+        {
+            return repo.Lookup<Commit>(commitSha) != null;
         }
     }
 }

--- a/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
@@ -49,9 +49,9 @@ namespace Incrementalist.ProjectSystem.Cmds
             }
 
             // validate the target branch
-            if (!DiffHelper.HasBranch(repo, _targetGitBranch))
+            if (!DiffHelper.HasBranch(repo, _targetGitBranch) && !DiffHelper.HasCommit(repo, _targetGitBranch))
             {
-                Logger.LogError("Current git repository doesn't have any branch named [{TargetBranch}]. Shutting down.",
+                Logger.LogError("Current git repository doesn't have any branch or commit [{TargetBranch}]. Shutting down.",
                     _targetGitBranch);
                 return new Dictionary<AbsolutePath, SlnFile>();
             }


### PR DESCRIPTION
Usage
`incrementalist --dry --compare-sha 570ed15232e40d293ca58ee92ff0eeec02c3904e`

Compares against a commit instead of a target branch head

The point is to allow a trunk based build in GitHub Actions to detect affected projects. 

We are standing on a merged trunk/dev branch, but are provided a SHA for the previous commit