### PR TITLE
Fix missing project dependency detection

### DIFF
--- a/src/Incrementalist.Cmd/Commands/EmitDependencyGraphTask.cs
+++ b/src/Incrementalist.Cmd/Commands/EmitDependencyGraphTask.cs
@@ -115,11 +115,11 @@ namespace Incrementalist.Cmd.Commands
             }
 
             // Log the breakdown of modified files by type
-            var modifiedSourceFiles = affectedFiles.Count(x => x.Value.FileType == FileType.Code);
-            var modifiedProjectFiles = affectedFiles.Count(x => x.Value.FileType == FileType.Project);
-            var modifiedSolutionFiles = affectedFiles.Count(x => x.Value.FileType == FileType.Solution);
-            var modifiedScriptFiles = affectedFiles.Count(x => x.Value.FileType == FileType.Script);
-            var modifiedOtherFiles = affectedFiles.Count(x => x.Value.FileType == FileType.Other);
+            var modifiedSourceFiles = affectedFiles.Count(x => x.Value.Any(f => f.FileType == FileType.Code));
+            var modifiedProjectFiles = affectedFiles.Count(x => x.Value.Any(f => f.FileType == FileType.Project));
+            var modifiedSolutionFiles = affectedFiles.Count(x => x.Value.Any(f => f.FileType == FileType.Solution));
+            var modifiedScriptFiles = affectedFiles.Count(x => x.Value.Any(f => f.FileType == FileType.Script));
+            var modifiedOtherFiles = affectedFiles.Count(x => x.Value.Any(f => f.FileType == FileType.Other));
             Logger.LogInformation(
                 "Modified files breakdown: {SourceFiles} source files, {ProjectFiles} project files, {SolutionFiles} solution files, {ScriptFiles} script files, {OtherFiles} other files",
                 modifiedSourceFiles, modifiedProjectFiles, modifiedSolutionFiles, modifiedScriptFiles,
@@ -127,8 +127,8 @@ namespace Incrementalist.Cmd.Commands
 
             // Check if any of the affected files require a solution-wide build
             Logger.LogInformation("Analyzing solution-wide impact...");
-            var projectFiles = allFiles.Where(x => x.Value.FileType == FileType.Project)
-                .Select(pair => new SlnFileWithPath(pair.Key, pair.Value))
+            var projectFiles = allFiles.Where(x => x.Value is [{ FileType: FileType.Project }])
+                .Select(pair => new SlnFileWithPath(pair.Key, pair.Value[0]))
                 .ToList();
             var projectImports = ProjectImportsFinder.FindProjectImports(projectFiles);
             var importDetector = new SolutionWideChangeDetector(projectImports);
@@ -140,7 +140,7 @@ namespace Incrementalist.Cmd.Commands
             }
 
             // Get the list of affected project files directly
-            var directlyAffectedProjects = affectedFiles.Where(x => x.Value.FileType == FileType.Project)
+            var directlyAffectedProjects = affectedFiles.Where(x => x.Value.Any(f => f.FileType == FileType.Project))
                 .Select(x => x.Key)
                 .ToList();
 

--- a/src/Incrementalist.Tests/Dependencies/EmitDependencyGraphSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/EmitDependencyGraphSpecs.cs
@@ -49,13 +49,18 @@ public class EmitDependencyGraphSpecs : IAsyncLifetime
             .AddFolder("src", f1Builder =>
             {
                 f1Builder.AddProject(ProjectA,
-                    (_, p1Builder) => { p1Builder.WithFile("HelloWorld.cs", CsharpSamples.HelloClass); });
+                    (_, p1Builder) =>
+                    {
+                        p1Builder.WithFile("HelloWorld.cs", CsharpSamples.HelloClass);
+                        p1Builder.WithTargetFrameworks([TargetFramework.Net8, TargetFramework.Net9, TargetFramework.NetStandard2_0, TargetFramework.NetStandard2_1]);
+                    });
 
                 f1Builder.AddProject(ProjectB, (otherProjects, p2Builder) =>
                 {
                     p2Builder.WithFile("GoodBye.cs", CsharpSamples.GoodbyeClassWithNamespace);
                     var projectA = otherProjects.First(p => p.NameWithoutExtension == ProjectA);
                     p2Builder.WithProjectReference(projectA);
+                    p2Builder.WithTargetFrameworks([TargetFramework.Net8, TargetFramework.Net9, TargetFramework.NetStandard2_0, TargetFramework.NetStandard2_1]);
                 });
 
                 // a third project, C, with no references to anyone else
@@ -69,6 +74,7 @@ public class EmitDependencyGraphSpecs : IAsyncLifetime
                     p3Builder.WithFile("HelloWorldTests.cs", CsharpSamples.BarClass);
                     var projectB = otherProjects.First(p => p.NameWithoutExtension == ProjectB);
                     p3Builder.WithProjectReference(projectB);
+                    p3Builder.WithTargetFrameworks([TargetFramework.Net9]);
                 });
             })
             .Build();

--- a/src/Incrementalist.Tests/Dependencies/ProjectImportsTrackingSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/ProjectImportsTrackingSpecs.cs
@@ -75,9 +75,9 @@ namespace Incrementalist.Tests.Dependencies
 
             var cmd = new FilterAffectedProjectFilesCmd(new TestOutputLogger(_outputHelper), CancellationToken.None,
                 Repository.BasePath, "master");
-            var solutionFiles = new Dictionary<AbsolutePath, SlnFile>()
+            var solutionFiles = new Dictionary<AbsolutePath, SlnFile[]>()
             {
-                [projectFilePath] = new SlnFile(FileType.Project, ProjectId.CreateNewId())
+                [projectFilePath] = [new SlnFile(FileType.Project, ProjectId.CreateNewId())]
             };
             var filteredAffectedFiles = await cmd.Process(Task.FromResult(solutionFiles));
             Assert.Single(filteredAffectedFiles);

--- a/src/Incrementalist/ProjectSystem/Cmds/ComputeDependencyGraphCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/ComputeDependencyGraphCmd.cs
@@ -20,7 +20,7 @@ namespace Incrementalist.ProjectSystem.Cmds
     ///     and emits a topologically sorted set of project file names to be used during testing.
     /// </summary>
     public sealed class
-        ComputeDependencyGraphCmd : BuildCommandBase<Dictionary<AbsolutePath, SlnFile>,
+        ComputeDependencyGraphCmd : BuildCommandBase<Dictionary<AbsolutePath, SlnFile[]>,
         Dictionary<AbsolutePath, ICollection<AbsolutePath>>>
     {
         private readonly Solution _solution;
@@ -32,7 +32,7 @@ namespace Incrementalist.ProjectSystem.Cmds
         }
 
         protected override async Task<Dictionary<AbsolutePath, ICollection<AbsolutePath>>> ProcessImpl(
-            Task<Dictionary<AbsolutePath, SlnFile>> previousTask)
+            Task<Dictionary<AbsolutePath, SlnFile[]>> previousTask)
         {
             var affectedSlnFiles = await previousTask;
 
@@ -51,9 +51,9 @@ namespace Incrementalist.ProjectSystem.Cmds
              * We have to gather up each unique project file separately in this case.
              */
             List<ProjectId> additionalProjectIds = [];
-            if (affectedSlnFiles.Any(x => x.Value.FileType == FileType.Project))
+            if (affectedSlnFiles.Any(x => x.Value.Any(f => f.FileType == FileType.Project)))
             {
-                foreach (var proj in affectedSlnFiles.Where(x => x.Value.FileType == FileType.Project))
+                foreach (var proj in affectedSlnFiles.Where(x => x.Value.Any(f => f.FileType == FileType.Project)))
                     additionalProjectIds.AddRange(_solution.Projects
                         .Where(x => x.FilePath != null && x.FilePath.Equals(proj.Key.Path)).Select(x => x.Id));
             }
@@ -78,8 +78,8 @@ namespace Incrementalist.ProjectSystem.Cmds
             }
 
             var uniqueProjectIds = affectedSlnFiles
-                .Where(c => c.Value.ProjectId != null)
-                .Select(x => x.Value.ProjectId!).Concat(additionalProjectIds)
+                .Where(c => c.Value.All(f => f.ProjectId != null))
+                .SelectMany(x => x.Value.Select(f => f.ProjectId!)).Concat(additionalProjectIds)
                 .Distinct().ToList();
 
             Logger.LogDebug("Evaluating {Count} unique project IDs.", uniqueProjectIds.Count);

--- a/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/FilterAffectedProjectFilesCmd.cs
@@ -21,8 +21,8 @@ namespace Incrementalist.ProjectSystem.Cmds
     ///     they were touched via the GitDiff.
     /// </summary>
     public sealed class
-        FilterAffectedProjectFilesCmd : BuildCommandBase<Dictionary<AbsolutePath, SlnFile>,
-        Dictionary<AbsolutePath, SlnFile>>
+        FilterAffectedProjectFilesCmd : BuildCommandBase<Dictionary<AbsolutePath, SlnFile[]>,
+        Dictionary<AbsolutePath, SlnFile[]>>
     {
         private readonly string _targetGitBranch;
         private readonly AbsolutePath _workingDirectory;
@@ -35,8 +35,8 @@ namespace Incrementalist.ProjectSystem.Cmds
             _targetGitBranch = targetGitBranch;
         }
 
-        protected override async Task<Dictionary<AbsolutePath, SlnFile>> ProcessImpl(
-            Task<Dictionary<AbsolutePath, SlnFile>> previousTask)
+        protected override async Task<Dictionary<AbsolutePath, SlnFile[]>> ProcessImpl(
+            Task<Dictionary<AbsolutePath, SlnFile[]>> previousTask)
         {
             var fileDictObj = await previousTask;
 
@@ -45,7 +45,7 @@ namespace Incrementalist.ProjectSystem.Cmds
             {
                 Logger.LogError("Unable to find Git repository located in {WorkingDirectory}. Shutting down.",
                     _workingDirectory);
-                return new Dictionary<AbsolutePath, SlnFile>();
+                return [];
             }
 
             // validate the target branch
@@ -53,20 +53,20 @@ namespace Incrementalist.ProjectSystem.Cmds
             {
                 Logger.LogError("Current git repository doesn't have any branch named [{TargetBranch}]. Shutting down.",
                     _targetGitBranch);
-                return new Dictionary<AbsolutePath, SlnFile>();
+                return [];
             }
 
             var affectedFiles = DiffHelper.ChangedFiles(repo, _targetGitBranch).ToList();
 
-            var projectFiles = fileDictObj.Where(x => x.Value.FileType == FileType.Project).ToList();
+            var projectFiles = fileDictObj.Where(x => x.Value is [{ FileType: FileType.Project }]).ToList();
             var projectFolders = projectFiles.Where(x => Path.GetDirectoryName(x.Key.Path) is not null)
                 .ToLookup(x => new AbsolutePath(Path.GetDirectoryName(x.Key.Path)!), v => Tuple.Create(v.Key, v.Value));
             var projectImports =
                 ProjectImportsFinder.FindProjectImports(projectFiles.Select(pair =>
-                    new SlnFileWithPath(pair.Key, pair.Value)));
+                    new SlnFileWithPath(pair.Key, pair.Value[0])));
 
             // filter out any files that aren't affected by the diff
-            var newDict = new Dictionary<AbsolutePath, SlnFile>();
+            var newDict = new Dictionary<AbsolutePath, SlnFile[]>();
             foreach (var file in affectedFiles)
             {
                 Logger.LogDebug("Affected file: {FilePath}", file);
@@ -86,7 +86,7 @@ namespace Incrementalist.ProjectSystem.Cmds
                     if (SolutionWideChangeDetector.IsSolutionWideFile(file))
                     {
                         Logger.LogInformation("Adding solution-wide file {File} to the set of affected files.", file);
-                        newDict[file] = new SlnFile(FileType.Other, null);
+                        newDict[file] = [new SlnFile(FileType.Other, null)];
                         continue;
                     }
 
@@ -110,7 +110,7 @@ namespace Incrementalist.ProjectSystem.Cmds
                     // Mark all dependant as affected
                     foreach (var dependentProject in import.DependentProjects)
                     {
-                        newDict[dependentProject.Path] = dependentProject.File;
+                        newDict[dependentProject.Path] = [dependentProject.File];
                     }
                 }
             }

--- a/src/Incrementalist/ProjectSystem/Cmds/GatherAllFilesInSolutionCmd.cs
+++ b/src/Incrementalist/ProjectSystem/Cmds/GatherAllFilesInSolutionCmd.cs
@@ -17,7 +17,7 @@ namespace Incrementalist.ProjectSystem.Cmds
     /// <summary>
     ///     Gathers all of the files in a solution and categorizes them.
     /// </summary>
-    public sealed class GatherAllFilesInSolutionCmd : BuildCommandBase<Solution, Dictionary<AbsolutePath, SlnFile>>
+    public sealed class GatherAllFilesInSolutionCmd : BuildCommandBase<Solution, Dictionary<AbsolutePath, SlnFile[]>>
     {
         private readonly AbsolutePath _workingDirectory;
 
@@ -28,7 +28,7 @@ namespace Incrementalist.ProjectSystem.Cmds
             _workingDirectory = workingDirectory;
         }
 
-        protected override async Task<Dictionary<AbsolutePath, SlnFile>> ProcessImpl(Task<Solution> previousTask)
+        protected override async Task<Dictionary<AbsolutePath, SlnFile[]>> ProcessImpl(Task<Solution> previousTask)
         {
             var slnObject = await previousTask;
             Contract.Assert(slnObject is not null,

--- a/src/Incrementalist/ProjectSystem/SolutionAnalyzer.cs
+++ b/src/Incrementalist/ProjectSystem/SolutionAnalyzer.cs
@@ -44,7 +44,7 @@ namespace Incrementalist.ProjectSystem
         /// <param name="sln">The Solution file.</param>
         /// <param name="workingFolder"></param>
         /// <returns>A flattened list of all files inside the solution.</returns>
-        public static Dictionary<AbsolutePath, SlnFile> AllSolutionFiles(Solution sln, AbsolutePath workingFolder)
+        public static Dictionary<AbsolutePath, SlnFile[]> AllSolutionFiles(Solution sln, AbsolutePath workingFolder)
         {
             // throw if the solution's file path is null
             ArgumentNullException.ThrowIfNull(sln.FilePath, nameof(sln.FilePath));
@@ -55,17 +55,17 @@ namespace Incrementalist.ProjectSystem
                     document => new SlnFile(
                         document.SourceCodeKind == SourceCodeKind.Regular ? FileType.Code : FileType.Script,
                         document.Project.Id))
-                .ToDictionary(x => new AbsolutePath(Path.GetFullPath(x.Key!)), x => x.First()).ToList()
+                .ToDictionary(x => new AbsolutePath(Path.GetFullPath(x.Key!)), x => x.ToArray())
                 .Concat(sln.Projects.Where(x => x.FilePath != null).Select(x =>
-                        new KeyValuePair<AbsolutePath, SlnFile>(new AbsolutePath(Path.GetFullPath(x.FilePath!)),
-                            new SlnFile(FileType.Project, x.Id)))
+                        new KeyValuePair<AbsolutePath, SlnFile[]>(new AbsolutePath(Path.GetFullPath(x.FilePath!)),
+                            [new SlnFile(FileType.Project, x.Id)]))
                     .Concat([
-                        new KeyValuePair<AbsolutePath, SlnFile>
-                            (new AbsolutePath(Path.GetFullPath(sln.FilePath)), new SlnFile(FileType.Solution, null))
+                        new KeyValuePair<AbsolutePath, SlnFile[]>
+                            (new AbsolutePath(Path.GetFullPath(sln.FilePath)), [new SlnFile(FileType.Solution, null)])
                     ]));
 
             // need to de-duplicate
-            var finalFiles = new Dictionary<AbsolutePath, SlnFile>();
+            var finalFiles = new Dictionary<AbsolutePath, SlnFile[]>();
             foreach (var file in allPossibleFiles)
             {
                 finalFiles[file.Key] = file.Value;


### PR DESCRIPTION
When multiple target frameworks are defined, the dictionary of source file to project must keep all the project ids. Choosing just one with `.First()` can lead to failure because the project id might correspond to a target framework that does not match the target framework of the referencing project.

The first commit (2829813a94d4d286ad36ec4b973d7d8704ed57c7) modifies `EmitDependencyGraphSpecs` to add different targets across project dependencies to demonstrate the bug.

The second commit (4b1a2dbb18414624a254990c2d0ea8f799ac5107) fixes the bug exposed in the first commit.