### PR TITLE
Fix running tests on macOS

### DIFF
--- a/src/Incrementalist.Tests/Helpers/DisposableRepository.cs
+++ b/src/Incrementalist.Tests/Helpers/DisposableRepository.cs
@@ -49,18 +49,19 @@ namespace Incrementalist.Tests.Helpers
 
         public DisposableRepository(AbsolutePath basePath)
         {
-            BasePath = basePath;
+            var repoPath = new DirectoryInfo(Repository.Init(basePath.Path));
+            BasePath = new AbsolutePath(repoPath.Parent?.FullName ?? "");
+            Repository = new Repository(repoPath.FullName);
             Init();
         }
 
         public AbsolutePath BasePath { get; }
 
-        // Gets created via CTOR method call, so can't be null unless catastrophic failure
-        public Repository Repository { get; private set; } = null!;
+        public Repository Repository { get; }
 
         public void Dispose()
         {
-            Repository?.Dispose();
+            Repository.Dispose();
             for (var attempt = 1; attempt <= MaxDeleteAttempts; attempt++)
                 try
                 {
@@ -86,8 +87,6 @@ namespace Incrementalist.Tests.Helpers
 
         private void Init()
         {
-            var repoPath = Repository.Init(BasePath.Path);
-            Repository = new Repository(repoPath);
             var sig = CreateSignature();
             // add a .gitignore file to the repository immediately
             WriteFile(GitIgnoreFileName, GitIgnoreContent);

--- a/src/Incrementalist.Tests/Helpers/DisposableRepository.cs
+++ b/src/Incrementalist.Tests/Helpers/DisposableRepository.cs
@@ -91,7 +91,12 @@ namespace Incrementalist.Tests.Helpers
             // add a .gitignore file to the repository immediately
             WriteFile(GitIgnoreFileName, GitIgnoreContent);
             Repository.Commit("First", sig, sig);
-            //Repository.CreateBranch("master"); // setup the master branch initially
+            if (Repository.Refs.Head.TargetIdentifier != "refs/heads/master")
+            {
+                // ensure the default branch is named "master", see https://github.com/libgit2/libgit2sharp/issues/1964
+                var master = Repository.CreateBranch("master");
+                Repository.Refs.UpdateTarget(Repository.Refs.Head, master.Reference);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
On macOS, the temporary directory contains a symlink and all tests using `DisposableRepository` would fail with the following error:

```
System.ArgumentException
Unable to process file '/var/folders/62/pz7b9x0x7hv54vy47pllqlvw0000gn/T/edic1ukd/.gitignore'. This file is not located under the working directory of the repository ('/private/var/folders/62/pz7b9x0x7hv54vy47pllqlvw0000gn/T/edic1ukd/').
   at LibGit2Sharp.RepositoryExtensions.BuildRelativePathFrom(IRepository repo, String path) in /_/LibGit2Sharp/RepositoryExtensions.cs:line 215
   at LibGit2Sharp.Repository.ToFilePaths(IEnumerable`1 paths) in /_/LibGit2Sharp/Repository.cs:line 1676
   at LibGit2Sharp.Diff.BuildDiffList(ObjectId oldTreeId, ObjectId newTreeId, TreeComparisonHandleRetriever comparisonHandleRetriever, DiffModifiers diffOptions, IEnumerable`1 paths, ExplicitPathsOptions explicitPathsOptions, CompareOptions compareOptions) in /_/LibGit2Sharp/Diff.cs:line 544
   at LibGit2Sharp.Diff.Compare[T](DiffModifiers diffOptions, IEnumerable`1 paths, ExplicitPathsOptions explicitPathsOptions, CompareOptions compareOptions) in /_/LibGit2Sharp/Diff.cs:line 483
   at LibGit2Sharp.Commands.Stage(IRepository repository, IEnumerable`1 paths, StageOptions stageOptions) in /_/LibGit2Sharp/Commands/Stage.cs:line 77
   at LibGit2Sharp.Commands.Stage(IRepository repository, String path) in /_/LibGit2Sharp/Commands/Stage.cs:line 25
   at Incrementalist.Tests.Helpers.DisposableRepository.WriteFile(String fileName, String fileText) in ~/Incrementalist/src/Incrementalist.Tests/Helpers/DisposableRepository.cs:line 131
   at Incrementalist.Tests.Helpers.DisposableRepository.Init() in ~/Incrementalist/src/Incrementalist.Tests/Helpers/DisposableRepository.cs:line 93
   at Incrementalist.Tests.Helpers.DisposableRepository..ctor(AbsolutePath basePath) in ~/Incrementalist/src/Incrementalist.Tests/Helpers/DisposableRepository.cs:line 56
   at Incrementalist.Tests.Helpers.DisposableRepository..ctor() in ~/Incrementalist/src/Incrementalist.Tests/Helpers/DisposableRepository.cs:line 46
   at Incrementalist.Tests.Git.GitBranchDetectionSpecs..ctor() in ~/Incrementalist/src/Incrementalist.Tests/Git/GitBranchDetectionSpecs.cs:line 18
   at System.RuntimeType.CreateInstanceDefaultCtor(Boolean publicOnly, Boolean wrapExceptions)
```

See also https://github.com/libgit2/libgit2sharp/issues/1945