### PR TITLE
Reduce default timeout to 1 minute

### DIFF
--- a/src/Incrementalist/BuildSettings.cs
+++ b/src/Incrementalist/BuildSettings.cs
@@ -16,7 +16,7 @@ namespace Incrementalist
     /// </summary>
     public sealed class BuildSettings
     {
-        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(100);
+        public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(1);
 
         public BuildSettings(string targetBranch, RelativePath solutionFile, AbsolutePath workingDirectory,
             IReadOnlyList<string> skipGlobs, IReadOnlyList<string> targetGlobs, string? nameApplicationToStart, TimeSpan? timeoutDuration = null)


### PR DESCRIPTION
The 100 minutes were used to avoid timeouts while debugging. It accidentally slipped into 5146500b5f67b44a2be513d79524f80cf2748673.