### PR TITLE
Add support for .slnx solution format

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,37 @@
+#### 1.2.0-beta.1 October 31 2025 ####
+
+**BETA RELEASE - .NET 9.0 and .slnx Support**
+
+This is a beta release with upgraded dependencies to support the new XML-based .slnx solution format and .NET 9.0.
+
+**Major Changes:**
+
+* **Upgraded to .NET 9.0:**
+  Updated target framework from net8.0 to net9.0 to support newer MSBuild and Roslyn dependencies.
+
+* **Added .slnx Solution Format Support:**
+  Full support for the new XML-based .slnx solution format in both Workspace and Static Graph build engines.
+
+* **Dependency Upgrades:**
+  - Roslyn (Microsoft.CodeAnalysis): 4.14.0 → 5.0.0-2.final (prerelease)
+  - MSBuild: 17.11.48 → 17.14.28
+  - Added Microsoft.CodeAnalysis.Common package
+
+* **Improved F# Project Handling:**
+  F# projects now use StaticGraphBuildEngine for better compatibility with Roslyn 5.0+.
+
+**Breaking Changes:**
+
+* Requires .NET 9.0 SDK or later
+* Uses prerelease Roslyn dependency (5.0.0-2.final) until stable Roslyn 5.0 is released
+
+**Bug Fixes:**
+
+* Fixed deprecated Workspace.WorkspaceFailed API usage
+* Updated F# test samples to use net8.0 target framework
+
+Fixes #405
+
 #### 1.1.0 September 3 2025 ####
 
 **Major New Features & Improvements:**

--- a/build-system/azure-pipeline.template.yaml
+++ b/build-system/azure-pipeline.template.yaml
@@ -20,6 +20,12 @@ jobs:
         inputs:
           useGlobalJson: true
           
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK 8.0'
+        inputs:
+          packageType: sdk
+          version: 8.0.416
+      
       # Version bump
       - task: PowerShell@2
         displayName: 'Bump version from RELEASE_NOTES.md'

--- a/build-system/windows-release.yaml
+++ b/build-system/windows-release.yaml
@@ -26,6 +26,12 @@ steps:
   inputs:
     useGlobalJson: true
 
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK 8.0'
+  inputs:
+    packageType: sdk
+    version: 8.0.416
+  
 # Version bump from release notes
 - task: PowerShell@2
   displayName: 'Update version from RELEASE_NOTES.md'

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-      "version": "9.0.200",
+      "version": "10.0.101",
       "rollForward": "major"
   }
 } 

--- a/scripts/integration-tests.ps1
+++ b/scripts/integration-tests.ps1
@@ -463,6 +463,7 @@ function Test-ComplexCommandArguments
             "run",
             "--engine", $BuildEngine,
             "-b", "dev",
+            "-t", "5", # 5 minute timeout - needed for dual-target (net8.0;net10.0) test runs
             "--", # Separator for dotnet command arguments
             "test",
             "--logger", "console;verbosity=detailed",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,34 +3,36 @@
     <Copyright>Copyright © 2015-$([System.DateTime]::Now.Year) Petabridge</Copyright>
     <Authors>Petabridge</Authors>
     <VersionPrefix>1.2.0-beta.1</VersionPrefix>
-    <PackageReleaseNotes>**BETA RELEASE - .NET 9.0 and .slnx Support**
+    <PackageReleaseNotes>**BETA RELEASE - Dual-Target .NET 8.0/.NET 10.0 with .slnx Support**
 
-This is a beta release with upgraded dependencies to support the new XML-based .slnx solution format and .NET 9.0.
+This is a beta release with dual-targeting support for .NET 8.0 and .NET 10.0, and adds support for the new XML-based .slnx solution format on .NET 9.0+.
 
 **Major Changes:**
 
-* **Upgraded to .NET 9.0:**
-  Updated target framework from net8.0 to net9.0 to support newer MSBuild and Roslyn dependencies.
+* **Dual-Targeting .NET 8.0 and .NET 10.0:**
+  The library and CLI tool now target both .NET 8.0 and .NET 10.0 to support a wider range of environments.
 
-* **Added .slnx Solution Format Support:**
+* **Added .slnx Solution Format Support (.NET 9.0+ only):**
   Full support for the new XML-based .slnx solution format in both Workspace and Static Graph build engines.
+  Note: .slnx support requires MSBuild 17.12.6+ and Roslyn 5.0.0+, which are only available on .NET 9.0+.
+  The .NET 8.0 build does not support .slnx files.
 
-* **Dependency Upgrades:**
-  - Roslyn (Microsoft.CodeAnalysis): 4.14.0 → 5.0.0-2.final (prerelease)
-  - MSBuild: 17.11.48 → 17.14.28
-  - Added Microsoft.CodeAnalysis.Common package
+* **TFM-Conditional Dependencies:**
+  - .NET 8.0: MSBuild 17.11.48, Roslyn 4.14.0
+  - .NET 10.0: MSBuild 18.0.2, Roslyn 5.0.0
 
 * **Improved F# Project Handling:**
   F# projects now use StaticGraphBuildEngine for better compatibility with Roslyn 5.0+.
 
-**Breaking Changes:**
+**Important Notes:**
 
-* Requires .NET 9.0 SDK or later
-* Uses prerelease Roslyn dependency (5.0.0-2.final) until stable Roslyn 5.0 is released
+* .slnx solution format support is only available when running on .NET 9.0 or later
+* The .NET 8.0 build only supports traditional .sln solution files
 
 **Bug Fixes:**
 
 * Fixed deprecated Workspace.WorkspaceFailed API usage
+* Fixed multi-targeted project deduplication in StaticGraphBuildEngine
 * Updated F# test samples to use net8.0 target framework
 
 Fixes #405</PackageReleaseNotes>
@@ -49,11 +51,19 @@ Fixes #405</PackageReleaseNotes>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.9.3</XunitVersion>
     <TestSdkVersion>17.14.1</TestSdkVersion>
-    <!-- .slnx support added in 17.12.6: https://github.com/dotnet/msbuild/pull/10794 -->
-    <MicrosoftBuildVersion>18.0.2</MicrosoftBuildVersion>
-    <!-- .slnx support added in 5.0.0-2.final: https://www.nuget.org/packages/Microsoft.CodeAnalysis.Workspaces.MSBuild/5.0.0-2.final -->
-    <RoslynVersion>5.0.0</RoslynVersion>
     <NugetVersion>6.14.0</NugetVersion>
+  </PropertyGroup>
+  <!-- .NET 8.0 versions (no .slnx support - MSBuild 17.12.6+ requires .NET 9.0+) -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <MicrosoftBuildVersion>17.11.48</MicrosoftBuildVersion>
+    <RoslynVersion>4.14.0</RoslynVersion>
+  </PropertyGroup>
+  <!-- .NET 9.0+ versions (with .slnx support) -->
+  <!-- .slnx support added in MSBuild 17.12.6: https://github.com/dotnet/msbuild/pull/10794 -->
+  <!-- .slnx support added in Roslyn 5.0.0-2.final: https://www.nuget.org/packages/Microsoft.CodeAnalysis.Workspaces.MSBuild/5.0.0-2.final -->
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net8.0'">
+    <MicrosoftBuildVersion>18.0.2</MicrosoftBuildVersion>
+    <RoslynVersion>5.0.0</RoslynVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\..\README.md" Pack="true" Visible="false" PackagePath="\" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,7 +52,7 @@ Fixes #405</PackageReleaseNotes>
     <!-- .slnx support added in 17.12.6: https://github.com/dotnet/msbuild/pull/10794 -->
     <MicrosoftBuildVersion>17.14.28</MicrosoftBuildVersion>
     <!-- .slnx support added in 5.0.0-2.final: https://www.nuget.org/packages/Microsoft.CodeAnalysis.Workspaces.MSBuild/5.0.0-2.final -->
-    <RoslynVersion>5.0.0-2.final</RoslynVersion>
+    <RoslynVersion>5.0.0</RoslynVersion>
     <NugetVersion>6.14.0</NugetVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,33 +2,38 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-$([System.DateTime]::Now.Year) Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>1.1.0</VersionPrefix>
-    <PackageReleaseNotes>**Major New Features &amp; Improvements:**
+    <VersionPrefix>1.2.0-beta.1</VersionPrefix>
+    <PackageReleaseNotes>**BETA RELEASE - .NET 9.0 and .slnx Support**
 
-* **Custom Process Execution with `run-process` Verb:**  
-  You can now use the new `run-process` verb to run any process (not just `dotnet`) against affected projects. This enables advanced scenarios, such as running custom scripts or tools before or after your build/test steps.  
+This is a beta release with upgraded dependencies to support the new XML-based .slnx solution format and .NET 9.0.
 
-  _Example:_  
+**Major Changes:**
 
-  ```shell
-  incrementalist run-process --process /bin/bash -- echo 'Hello from Incrementalist!'
-  ```
+* **Upgraded to .NET 9.0:**
+  Updated target framework from net8.0 to net9.0 to support newer MSBuild and Roslyn dependencies.
 
-* **Significant Performance Boost with Static Graph Engine:**  
-  Incrementalist now uses the MSBuild Static Graph engine by default for solution and project parsing. This change should make Incrementalist _significantly_ faster, especially on large solutions. The previous engine is still available via `--engine Workspace` for compatibility and comparison.
+* **Added .slnx Solution Format Support:**
+  Full support for the new XML-based .slnx solution format in both Workspace and Static Graph build engines.
 
-* **JSON Schema for Configuration Files:**  
-  Added JSON schema support for `incrementalist.json` configuration files, enabling IDE IntelliSense and validation. This makes it easier to write and maintain configuration files with autocomplete and error checking.
+* **Dependency Upgrades:**
+  - Roslyn (Microsoft.CodeAnalysis): 4.14.0 → 5.0.0-2.final (prerelease)
+  - MSBuild: 17.11.48 → 17.14.28
+  - Added Microsoft.CodeAnalysis.Common package
+
+* **Improved F# Project Handling:**
+  F# projects now use StaticGraphBuildEngine for better compatibility with Roslyn 5.0+.
+
+**Breaking Changes:**
+
+* Requires .NET 9.0 SDK or later
+* Uses prerelease Roslyn dependency (5.0.0-2.final) until stable Roslyn 5.0 is released
 
 **Bug Fixes:**
 
-* Fixed running tests on macOS by resolving symlink issues in temporary directories.
-* Improved project dependency detection logic for solutions with multiple target frameworks.
-* (Temporary) Reverted a previous dependency detection fix due to downstream issues.
+* Fixed deprecated Workspace.WorkspaceFailed API usage
+* Updated F# test samples to use net8.0 target framework
 
-**Documentation:**
-
-* Added a new page with real-world usage examples.</PackageReleaseNotes>
+Fixes #405</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIcon>incrementalist-logo-dark.png</PackageIcon>
     <PackageProjectUrl>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -44,8 +44,10 @@
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.9.3</XunitVersion>
     <TestSdkVersion>17.14.1</TestSdkVersion>
-    <MicrosoftBuildVersion>17.11.48</MicrosoftBuildVersion>
-    <RoslynVersion>4.14.0</RoslynVersion>
+    <!-- .slnx support added in 17.12.6: https://github.com/dotnet/msbuild/pull/10794 -->
+    <MicrosoftBuildVersion>17.14.28</MicrosoftBuildVersion>
+    <!-- .slnx support added in 5.0.0-2.final: https://www.nuget.org/packages/Microsoft.CodeAnalysis.Workspaces.MSBuild/5.0.0-2.final -->
+    <RoslynVersion>5.0.0-2.final</RoslynVersion>
     <NugetVersion>6.14.0</NugetVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -50,7 +50,7 @@ Fixes #405</PackageReleaseNotes>
     <XunitVersion>2.9.3</XunitVersion>
     <TestSdkVersion>17.14.1</TestSdkVersion>
     <!-- .slnx support added in 17.12.6: https://github.com/dotnet/msbuild/pull/10794 -->
-    <MicrosoftBuildVersion>17.14.28</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>18.0.2</MicrosoftBuildVersion>
     <!-- .slnx support added in 5.0.0-2.final: https://www.nuget.org/packages/Microsoft.CodeAnalysis.Workspaces.MSBuild/5.0.0-2.final -->
     <RoslynVersion>5.0.0</RoslynVersion>
     <NugetVersion>6.14.0</NugetVersion>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,6 +5,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="Libgit2Sharp" Version="0.31.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="$(RoslynVersion)" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(RoslynVersion)" />
         <PackageVersion Include="CommandLineParser" Version="2.9.1" />
         <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />

--- a/src/Incrementalist.Cmd/BuildEngine.StaticGraph.cs
+++ b/src/Incrementalist.Cmd/BuildEngine.StaticGraph.cs
@@ -49,7 +49,11 @@ public sealed class StaticGraphSolution : Solution
     {
         _projectGraph = projectGraph;
         FilePath = filePath;
-        Projects = projectGraph.ProjectNodesTopologicallySorted.Select(x => new StaticGraphProject(this, x)).ToList();
+        // Deduplicate by FullPath - multi-targeted projects create separate nodes per target framework
+        Projects = projectGraph.ProjectNodesTopologicallySorted
+            .DistinctBy(x => x.ProjectInstance.FullPath)
+            .Select(x => new StaticGraphProject(this, x))
+            .ToList();
     }
 
     public override AbsolutePath FilePath { get; }
@@ -57,12 +61,19 @@ public sealed class StaticGraphSolution : Solution
 
     public override IReadOnlyCollection<Project> GetTransitiveProjects(Project project)
     {
-        var result = new List<Project>();
+        var result = new HashSet<Project>();
+        // Iterate all nodes for this project (one per target framework)
         foreach (var node in _projectGraph.ProjectNodesTopologicallySorted.Where(x => x.ProjectInstance.FullPath == project.FilePath.Path))
         {
-            result.AddRange(node.ReferencingProjects.Select(x => Projects.Single(p => ((StaticGraphProject)p).Node == x)));
+            foreach (var referencingNode in node.ReferencingProjects)
+            {
+                // Match by FullPath since Projects is deduplicated
+                var proj = Projects.SingleOrDefault(p => p.FilePath.Path == referencingNode.ProjectInstance.FullPath);
+                if (proj != null)
+                    result.Add(proj);
+            }
         }
-        return result;
+        return result.ToList();
     }
 }
 

--- a/src/Incrementalist.Cmd/BuildEngine.Workspace.cs
+++ b/src/Incrementalist.Cmd/BuildEngine.Workspace.cs
@@ -33,7 +33,7 @@ public sealed class WorkspaceBuildEngine(ILogger logger) : BuildEngine
         workspace.SkipUnrecognizedProjects = false;
 
         // Log any workspace loading issues
-#if NET9_0_OR_GREATER
+#if NET10_0_OR_GREATER
         workspace.RegisterWorkspaceFailedHandler(args =>
         {
             var message = $"Issue during workspace loading: {args.Diagnostic.Message}";

--- a/src/Incrementalist.Cmd/BuildEngine.Workspace.cs
+++ b/src/Incrementalist.Cmd/BuildEngine.Workspace.cs
@@ -33,6 +33,7 @@ public sealed class WorkspaceBuildEngine(ILogger logger) : BuildEngine
         workspace.SkipUnrecognizedProjects = false;
 
         // Log any workspace loading issues
+#if NET9_0_OR_GREATER
         workspace.RegisterWorkspaceFailedHandler(args =>
         {
             var message = $"Issue during workspace loading: {args.Diagnostic.Message}";
@@ -42,6 +43,17 @@ public sealed class WorkspaceBuildEngine(ILogger logger) : BuildEngine
 
             logger.Log(logLevel, message);
         });
+#else
+        workspace.WorkspaceFailed += (_, args) =>
+        {
+            var message = $"Issue during workspace loading: {args.Diagnostic.Message}";
+            var logLevel = args.Diagnostic.Kind == Microsoft.CodeAnalysis.WorkspaceDiagnosticKind.Failure
+                ? LogLevel.Error
+                : LogLevel.Warning;
+
+            logger.Log(logLevel, message);
+        };
+#endif
 
         // Roslyn does not support FSharp projects, but .fsproj has same structure as .csproj files,
         // so can treat them as a known project type to support diff tracking

--- a/src/Incrementalist.Cmd/BuildEngine.Workspace.cs
+++ b/src/Incrementalist.Cmd/BuildEngine.Workspace.cs
@@ -17,7 +17,37 @@ namespace Incrementalist.Cmd;
 
 public sealed class WorkspaceBuildEngine(ILogger logger) : BuildEngine
 {
-    private readonly MSBuildWorkspace _msBuild = MSBuildWorkspace.Create();
+    private readonly MSBuildWorkspace _msBuild = CreateWorkspace(logger);
+
+    private static MSBuildWorkspace CreateWorkspace(ILogger logger)
+    {
+        var properties = new Dictionary<string, string>
+        {
+            // Required for SDK-style projects
+            ["CheckForSystemRuntimeDependency"] = "true"
+        };
+
+        var workspace = MSBuildWorkspace.Create(properties);
+
+        // Configure workspace to not skip unrecognized projects
+        workspace.SkipUnrecognizedProjects = false;
+
+        // Log any workspace loading issues
+        workspace.RegisterWorkspaceFailedHandler(args =>
+        {
+            var message = $"Issue during workspace loading: {args.Diagnostic.Message}";
+            var logLevel = args.Diagnostic.Kind == Microsoft.CodeAnalysis.WorkspaceDiagnosticKind.Failure
+                ? LogLevel.Error
+                : LogLevel.Warning;
+
+            logger.Log(logLevel, message);
+        });
+
+        // Roslyn does not support FSharp projects, but .fsproj has same structure as .csproj files,
+        // so can treat them as a known project type to support diff tracking
+        workspace.AssociateFileExtensionWithLanguage("fsproj", Microsoft.CodeAnalysis.LanguageNames.CSharp);
+        return workspace;
+    }
 
     public override void Dispose() => _msBuild.Dispose();
 
@@ -28,6 +58,14 @@ public sealed class WorkspaceBuildEngine(ILogger logger) : BuildEngine
             logger.LogDebug("{Operation} project {Project} in {ElapsedTime}", x.Operation, x.FilePath, x.ElapsedTime);
         });
         var solution = await _msBuild.OpenSolutionAsync(solutionFilePath.Path, progress, cancellationToken);
+
+        // Log loaded projects for debugging
+        logger.LogInformation("Loaded {ProjectCount} projects from solution:", solution.ProjectIds.Count);
+        foreach (var project in solution.Projects)
+        {
+            logger.LogInformation("  - {ProjectPath}", project.FilePath);
+        }
+
         return new WorkspaceSolution(solution);
     }
 }

--- a/src/Incrementalist.Cmd/BuildEngine.Workspace.cs
+++ b/src/Incrementalist.Cmd/BuildEngine.Workspace.cs
@@ -59,12 +59,8 @@ public sealed class WorkspaceBuildEngine(ILogger logger) : BuildEngine
         });
         var solution = await _msBuild.OpenSolutionAsync(solutionFilePath.Path, progress, cancellationToken);
 
-        // Log loaded projects for debugging
-        logger.LogInformation("Loaded {ProjectCount} projects from solution:", solution.ProjectIds.Count);
-        foreach (var project in solution.Projects)
-        {
-            logger.LogInformation("  - {ProjectPath}", project.FilePath);
-        }
+        // Log loaded project count at debug level
+        logger.LogDebug("Loaded {ProjectCount} projects from solution", solution.ProjectIds.Count);
 
         return new WorkspaceSolution(solution);
     }

--- a/src/Incrementalist.Cmd/Commands/LoadSolutionCmd.cs
+++ b/src/Incrementalist.Cmd/Commands/LoadSolutionCmd.cs
@@ -44,6 +44,7 @@ namespace Incrementalist.Cmd
             Contract.Assert(File.Exists(slnName), $"Expected to find {slnName} on the file system, but couldn't.");
 
             // Log any solution loading issues
+#if NET9_0_OR_GREATER
             _workspace.RegisterWorkspaceFailedHandler(args =>
             {
                 var message = $"Issue during solution loading: {args.Diagnostic.Message}";
@@ -53,6 +54,17 @@ namespace Incrementalist.Cmd
 
                 Logger.Log(logLevel, message);
             });
+#else
+            _workspace.WorkspaceFailed += (_, args) =>
+            {
+                var message = $"Issue during solution loading: {args.Diagnostic.Message}";
+                var logLevel = args.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure
+                    ? LogLevel.Error
+                    : LogLevel.Warning;
+
+                Logger.Log(logLevel, message);
+            };
+#endif
 
             // Roslyn does not support FSharp projects, but .fsproj has same structure as .csproj files,
             // so can treat them as a known project type to support diff tracking

--- a/src/Incrementalist.Cmd/Commands/LoadSolutionCmd.cs
+++ b/src/Incrementalist.Cmd/Commands/LoadSolutionCmd.cs
@@ -44,7 +44,7 @@ namespace Incrementalist.Cmd
             Contract.Assert(File.Exists(slnName), $"Expected to find {slnName} on the file system, but couldn't.");
 
             // Log any solution loading issues
-#if NET9_0_OR_GREATER
+#if NET10_0_OR_GREATER
             _workspace.RegisterWorkspaceFailedHandler(args =>
             {
                 var message = $"Issue during solution loading: {args.Diagnostic.Message}";

--- a/src/Incrementalist.Cmd/Commands/LoadSolutionCmd.cs
+++ b/src/Incrementalist.Cmd/Commands/LoadSolutionCmd.cs
@@ -44,15 +44,15 @@ namespace Incrementalist.Cmd
             Contract.Assert(File.Exists(slnName), $"Expected to find {slnName} on the file system, but couldn't.");
 
             // Log any solution loading issues
-            _workspace.WorkspaceFailed += (sender, args) =>
+            _workspace.RegisterWorkspaceFailedHandler(args =>
             {
-                var message = $"Issue during solution loading: {sender}: {args.Diagnostic.Message}";
+                var message = $"Issue during solution loading: {args.Diagnostic.Message}";
                 var logLevel = args.Diagnostic.Kind == WorkspaceDiagnosticKind.Failure
                     ? LogLevel.Error
                     : LogLevel.Warning;
 
                 Logger.Log(logLevel, message);
-            };
+            });
 
             // Roslyn does not support FSharp projects, but .fsproj has same structure as .csproj files,
             // so can treat them as a known project type to support diff tracking

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -3,7 +3,7 @@
         <ToolCommandName>incrementalist</ToolCommandName>
         <PackAsTool>true</PackAsTool>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <LangVersion>latest</LangVersion>

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -3,7 +3,7 @@
         <ToolCommandName>incrementalist</ToolCommandName>
         <PackAsTool>true</PackAsTool>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <RollForward>LatestMajor</RollForward>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <LangVersion>latest</LangVersion>

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -3,7 +3,7 @@
         <ToolCommandName>incrementalist</ToolCommandName>
         <PackAsTool>true</PackAsTool>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <RollForward>LatestMajor</RollForward>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <LangVersion>latest</LangVersion>

--- a/src/Incrementalist.Tests/Dependencies/EmitDependencyGraphSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/EmitDependencyGraphSpecs.cs
@@ -20,9 +20,12 @@ public abstract class EmitDependencyGraphSpecs : IAsyncLifetime
 
     public class StaticGraph(ITestOutputHelper outputHelper) : EmitDependencyGraphSpecs(outputHelper, logger => new StaticGraphBuildEngine(logger, verbose: false));
 
+#if NET9_0_OR_GREATER
+    // .slnx support requires MSBuild 17.12.6+ and Roslyn 5.0.0+, which require .NET 9.0+
     public class WorkspaceSlnx(ITestOutputHelper outputHelper) : EmitDependencyGraphSpecs(outputHelper, logger => new WorkspaceBuildEngine(logger), SolutionFormat.Slnx);
 
     public class StaticGraphSlnx(ITestOutputHelper outputHelper) : EmitDependencyGraphSpecs(outputHelper, logger => new StaticGraphBuildEngine(logger, verbose: false), SolutionFormat.Slnx);
+#endif
 
     private readonly BuildEngine _engine;
     private readonly TestSolutionModel _generatedTestSolution;

--- a/src/Incrementalist.Tests/Dependencies/EmitDependencyGraphSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/EmitDependencyGraphSpecs.cs
@@ -20,7 +20,7 @@ public abstract class EmitDependencyGraphSpecs : IAsyncLifetime
 
     public class StaticGraph(ITestOutputHelper outputHelper) : EmitDependencyGraphSpecs(outputHelper, logger => new StaticGraphBuildEngine(logger, verbose: false));
 
-#if NET9_0_OR_GREATER
+#if NET10_0_OR_GREATER
     // .slnx support requires MSBuild 17.12.6+ and Roslyn 5.0.0+, which require .NET 9.0+
     public class WorkspaceSlnx(ITestOutputHelper outputHelper) : EmitDependencyGraphSpecs(outputHelper, logger => new WorkspaceBuildEngine(logger), SolutionFormat.Slnx);
 

--- a/src/Incrementalist.Tests/Dependencies/EmitDependencyGraphSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/EmitDependencyGraphSpecs.cs
@@ -20,6 +20,10 @@ public abstract class EmitDependencyGraphSpecs : IAsyncLifetime
 
     public class StaticGraph(ITestOutputHelper outputHelper) : EmitDependencyGraphSpecs(outputHelper, logger => new StaticGraphBuildEngine(logger, verbose: false));
 
+    public class WorkspaceSlnx(ITestOutputHelper outputHelper) : EmitDependencyGraphSpecs(outputHelper, logger => new WorkspaceBuildEngine(logger), SolutionFormat.Slnx);
+
+    public class StaticGraphSlnx(ITestOutputHelper outputHelper) : EmitDependencyGraphSpecs(outputHelper, logger => new StaticGraphBuildEngine(logger, verbose: false), SolutionFormat.Slnx);
+
     private readonly BuildEngine _engine;
     private readonly TestSolutionModel _generatedTestSolution;
     private readonly ILogger _logger;
@@ -29,10 +33,10 @@ public abstract class EmitDependencyGraphSpecs : IAsyncLifetime
 
     public DisposableRepository Repository { get; }
 
-    protected EmitDependencyGraphSpecs(ITestOutputHelper outputHelper, Func<ILogger, BuildEngine> buildEngine)
+    protected EmitDependencyGraphSpecs(ITestOutputHelper outputHelper, Func<ILogger, BuildEngine> buildEngine, SolutionFormat format = SolutionFormat.Sln)
     {
         Repository = new DisposableRepository();
-        _generatedTestSolution = CreateSolution();
+        _generatedTestSolution = CreateSolution(format);
         _logger = new TestOutputLogger(outputHelper);
         _engine = buildEngine(_logger);
     }
@@ -45,7 +49,7 @@ public abstract class EmitDependencyGraphSpecs : IAsyncLifetime
     public const string ProjectA = "ProjectA";
     public const string ProjectC = "ProjectC";
 
-    private static TestSolutionModel CreateSolution()
+    private static TestSolutionModel CreateSolution(SolutionFormat format = SolutionFormat.Sln)
     {
         var solutionBuilder = new TestSolutionBuilder("SampleSolution")
             .AddFolder("src", f1Builder =>
@@ -79,6 +83,7 @@ public abstract class EmitDependencyGraphSpecs : IAsyncLifetime
                     p3Builder.WithTargetFrameworks([TargetFramework.Net9]);
                 });
             })
+            .WithSolutionFormat(format)
             .Build();
 
         return solutionBuilder;

--- a/src/Incrementalist.Tests/Dependencies/FSharpProjectsTrackingSpecs.cs
+++ b/src/Incrementalist.Tests/Dependencies/FSharpProjectsTrackingSpecs.cs
@@ -55,7 +55,8 @@ namespace Incrementalist.Tests.Dependencies
             var logger = new TestOutputLogger(_outputHelper);
             var settings = new BuildSettings("master", new RelativePath("FSharpSolution.sln"), Repository.BasePath, [],
                 [], "dotnet");
-            var emitTask = new EmitDependencyGraphTask(settings, new WorkspaceBuildEngine(logger), logger, CancellationToken.None);
+            // Note: Using StaticGraphBuildEngine instead of WorkspaceBuildEngine because Roslyn 5.0+ does not support F# projects
+            var emitTask = new EmitDependencyGraphTask(settings, new StaticGraphBuildEngine(logger, verbose: false), logger, CancellationToken.None);
 
             var buildResult = await emitTask.Run();
 

--- a/src/Incrementalist.Tests/Helpers/SolutionBuilder/SolutionBuilder.cs
+++ b/src/Incrementalist.Tests/Helpers/SolutionBuilder/SolutionBuilder.cs
@@ -19,8 +19,10 @@ namespace Incrementalist.Tests.Helpers;
 
 public enum SolutionFormat
 {
-    Slnx,
-    Sln
+    Sln,
+#if NET9_0_OR_GREATER
+    Slnx
+#endif
 }
 
 public sealed class TestSolutionBuilder
@@ -154,7 +156,9 @@ public sealed record TestSolutionModel(string Name, RelativePath BaseDirectory) 
     public FileName FileName => FileFormat switch
     {
         SolutionFormat.Sln => new FileName($"{Name}.sln"),
+#if NET9_0_OR_GREATER
         SolutionFormat.Slnx => new FileName($"{Name}.slnx"),
+#endif
         _ => throw new ArgumentOutOfRangeException(nameof(SolutionFormat))
     };
 
@@ -184,7 +188,9 @@ public static class SolutionSerializer
         return testSolution.FileFormat switch
         {
             SolutionFormat.Sln => SerializeSlnAsync(solutionModel).Result,
+#if NET9_0_OR_GREATER
             SolutionFormat.Slnx => SerializeSlnxAsync(solutionModel).Result,
+#endif
             _ => throw new ArgumentOutOfRangeException(nameof(testSolution.FileFormat))
         };
 
@@ -221,6 +227,7 @@ public static class SolutionSerializer
         return Encoding.UTF8.GetString(memoryStream.ToArray());
     }
 
+#if NET9_0_OR_GREATER
     public static async Task<string> SerializeSlnxAsync(SolutionModel testSolution)
     {
         using var memoryStream = new MemoryStream();
@@ -249,6 +256,7 @@ public static class SolutionSerializer
         //
         // return sb.ToString();
     }
+#endif
 }
 
 public sealed record SolutionFolder(string Name, ImmutableList<IMsBuildSerializable> Items) : IMsBuildSerializable

--- a/src/Incrementalist.Tests/Helpers/SolutionBuilder/SolutionBuilder.cs
+++ b/src/Incrementalist.Tests/Helpers/SolutionBuilder/SolutionBuilder.cs
@@ -20,7 +20,7 @@ namespace Incrementalist.Tests.Helpers;
 public enum SolutionFormat
 {
     Sln,
-#if NET9_0_OR_GREATER
+#if NET10_0_OR_GREATER
     Slnx
 #endif
 }
@@ -156,7 +156,7 @@ public sealed record TestSolutionModel(string Name, RelativePath BaseDirectory) 
     public FileName FileName => FileFormat switch
     {
         SolutionFormat.Sln => new FileName($"{Name}.sln"),
-#if NET9_0_OR_GREATER
+#if NET10_0_OR_GREATER
         SolutionFormat.Slnx => new FileName($"{Name}.slnx"),
 #endif
         _ => throw new ArgumentOutOfRangeException(nameof(SolutionFormat))
@@ -188,7 +188,7 @@ public static class SolutionSerializer
         return testSolution.FileFormat switch
         {
             SolutionFormat.Sln => SerializeSlnAsync(solutionModel).Result,
-#if NET9_0_OR_GREATER
+#if NET10_0_OR_GREATER
             SolutionFormat.Slnx => SerializeSlnxAsync(solutionModel).Result,
 #endif
             _ => throw new ArgumentOutOfRangeException(nameof(testSolution.FileFormat))
@@ -227,7 +227,7 @@ public static class SolutionSerializer
         return Encoding.UTF8.GetString(memoryStream.ToArray());
     }
 
-#if NET9_0_OR_GREATER
+#if NET10_0_OR_GREATER
     public static async Task<string> SerializeSlnxAsync(SolutionModel testSolution)
     {
         using var memoryStream = new MemoryStream();

--- a/src/Incrementalist.Tests/Incrementalist.Tests.csproj
+++ b/src/Incrementalist.Tests/Incrementalist.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/Incrementalist.Tests/Incrementalist.Tests.csproj
+++ b/src/Incrementalist.Tests/Incrementalist.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/Incrementalist.Tests/ProjectSystem/SolutionFinderSpecs.cs
+++ b/src/Incrementalist.Tests/ProjectSystem/SolutionFinderSpecs.cs
@@ -45,7 +45,7 @@ namespace Incrementalist.Tests.ProjectSystem
             Assert.EndsWith("MySolution.sln", solutions.First().Path);
         }
 
-#if NET9_0_OR_GREATER
+#if NET10_0_OR_GREATER
         /// <summary>
         /// https://github.com/petabridge/Incrementalist/issues/365
         /// .slnx support requires MSBuild 17.12.6+ and Roslyn 5.0.0+, which require .NET 9.0+

--- a/src/Incrementalist.Tests/ProjectSystem/SolutionFinderSpecs.cs
+++ b/src/Incrementalist.Tests/ProjectSystem/SolutionFinderSpecs.cs
@@ -45,8 +45,10 @@ namespace Incrementalist.Tests.ProjectSystem
             Assert.EndsWith("MySolution.sln", solutions.First().Path);
         }
 
+#if NET9_0_OR_GREATER
         /// <summary>
         /// https://github.com/petabridge/Incrementalist/issues/365
+        /// .slnx support requires MSBuild 17.12.6+ and Roslyn 5.0.0+, which require .NET 9.0+
         /// </summary>
         [Fact(DisplayName = "Should .slnx solution in root directory")]
         public void Should_Find_Slnx_Solution()
@@ -73,6 +75,7 @@ namespace Incrementalist.Tests.ProjectSystem
             Assert.Single(solutions);
             Assert.EndsWith("MySolution.slnx", solutions.First().Path);
         }
+#endif
 
         [Fact(DisplayName = "Should find multiple solutions in root directory")]
         public void Should_Find_Multiple_Solutions()

--- a/src/Incrementalist.Tests/Samples/FSharpSampleSolution/CSharpProject.xml
+++ b/src/Incrementalist.Tests/Samples/FSharpSampleSolution/CSharpProject.xml
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
 </Project>

--- a/src/Incrementalist.Tests/Samples/FSharpSampleSolution/FSharpProject.xml
+++ b/src/Incrementalist.Tests/Samples/FSharpSampleSolution/FSharpProject.xml
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
 </Project>

--- a/src/Incrementalist/Incrementalist.csproj
+++ b/src/Incrementalist/Incrementalist.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Description>Library for running incremental, Git-based builds and tests in .NET and .NET Core.</Description>
     </PropertyGroup>
 

--- a/src/Incrementalist/Incrementalist.csproj
+++ b/src/Incrementalist/Incrementalist.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Description>Library for running incremental, Git-based builds and tests in .NET and .NET Core.</Description>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Libgit2Sharp"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common"/>
         <PackageReference Include="Microsoft.Extensions.Logging"/>
     </ItemGroup>
 

--- a/src/Incrementalist/ProjectSystem/SolutionFinder.cs
+++ b/src/Incrementalist/ProjectSystem/SolutionFinder.cs
@@ -32,7 +32,7 @@ namespace Incrementalist.ProjectSystem
             if (string.IsNullOrEmpty(searchFilter))
             {
                 var slnFiles = Directory.EnumerateFileSystemEntries(folderPath.Path, "*.sln", finalSearchOption);
-#if NET9_0_OR_GREATER
+#if NET10_0_OR_GREATER
                 // .slnx support requires MSBuild 17.12.6+ and Roslyn 5.0.0+, which require .NET 9.0+
                 var slnxFiles = Directory.EnumerateFileSystemEntries(folderPath.Path, "*.slnx", finalSearchOption);
                 return slnFiles.Concat(slnxFiles).OrderBy(Path.GetFileName)

--- a/src/Incrementalist/ProjectSystem/SolutionFinder.cs
+++ b/src/Incrementalist/ProjectSystem/SolutionFinder.cs
@@ -11,15 +11,17 @@ using System.Linq;
 namespace Incrementalist.ProjectSystem
 {
     /// <summary>
-    ///     Used to look for .sln and .slnx files in a given directory.
+    ///     Used to look for .sln files (and .slnx files on .NET 9.0+) in a given directory.
     /// </summary>
     public static class SolutionFinder
     {
         /// <summary>
-        ///     Enumerate all the MSBuild solution files (.sln and .slnx) in a given folder.
+        ///     Enumerate all the MSBuild solution files in a given folder.
+        ///     On .NET 9.0+, this includes both .sln and .slnx files.
+        ///     On .NET 8.0, only .sln files are supported.
         /// </summary>
         /// <param name="folderPath">The top level path to search.</param>
-        /// <param name="searchFilter">Optional. A wildcard filter, e.g., "*.sln". If null or empty, defaults to searching for both "*.sln" and "*.slnx".</param>
+        /// <param name="searchFilter">Optional. A wildcard filter, e.g., "*.sln". If null or empty, defaults to searching for supported solution formats.</param>
         /// <param name="searchOption">Optional. Specifies whether to recurse subdirectories or not. Defaults to <see cref="SearchOption.AllDirectories"/>.</param>
         /// <returns>If any solutions are found, will return an enumerable list of their paths, ordered by filename.</returns>
         public static IEnumerable<RelativePath> GetSolutions(AbsolutePath folderPath, string? searchFilter = null,
@@ -29,11 +31,16 @@ namespace Incrementalist.ProjectSystem
 
             if (string.IsNullOrEmpty(searchFilter))
             {
-                // Search for both .sln and .slnx if no specific filter is provided
                 var slnFiles = Directory.EnumerateFileSystemEntries(folderPath.Path, "*.sln", finalSearchOption);
+#if NET9_0_OR_GREATER
+                // .slnx support requires MSBuild 17.12.6+ and Roslyn 5.0.0+, which require .NET 9.0+
                 var slnxFiles = Directory.EnumerateFileSystemEntries(folderPath.Path, "*.slnx", finalSearchOption);
                 return slnFiles.Concat(slnxFiles).OrderBy(Path.GetFileName)
                     .Select(c => folderPath.ComputeRelativePathToMe(new AbsolutePath(c)));
+#else
+                return slnFiles.OrderBy(Path.GetFileName)
+                    .Select(c => folderPath.ComputeRelativePathToMe(new AbsolutePath(c)));
+#endif
             }
 
             // Use the provided search filter


### PR DESCRIPTION
## Summary
Adds full support for the new XML-based .slnx solution format in both Workspace and Static Graph build engines.

## Changes
- Upgraded MSBuild from 17.11.48 to **17.14.28** (.slnx support added in 17.12.6 via https://github.com/dotnet/msbuild/pull/10794)
- Upgraded Roslyn from 4.14.0 to **5.0.0-2.final** (.slnx support added via https://github.com/dotnet/roslyn/pull/77326)
- Upgraded target framework from net8.0 to **net9.0** (required by MSBuild 17.12.6+)
- Added Microsoft.CodeAnalysis.Common package reference (previously transitive)
- Updated deprecated `Workspace.WorkspaceFailed` API to `RegisterWorkspaceFailedHandler`
- Added test coverage for .slnx format:
  - `WorkspaceSlnx` test class (6 tests)
  - `StaticGraphSlnx` test class (6 tests)

## Test Results
All 14 .slnx tests passing:
- ✅ WorkspaceSlnx: 6/6 passed
- ✅ StaticGraphSlnx: 6/6 passed  
- ✅ Other .slnx tests: 2/2 passed

Fixes #405