### PR TITLE
Release 1.2.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,40 @@
+#### 1.2.0 December 23 2025 ####
+
+**Stable Release - Parallel Execution Control**
+
+This stable release adds a new feature to control parallelism during build and test operations.
+
+**New Features:**
+
+* **Parallel Limit Control:**
+  Added `--parallel-limit` CLI option and `parallelLimit` configuration setting to limit the degree of parallelism when running tasks in parallel. This helps prevent memory exhaustion and random errors when many projects are affected in large solutions.
+
+  _Example:_
+
+  ```shell
+  incrementalist test --parallel --parallel-limit 4
+  ```
+
+  Or in `incrementalist.json`:
+
+  ```json
+  {
+    "parallelLimit": 4
+  }
+  ```
+
+**Documentation:**
+
+* Added comprehensive documentation for `--parallel-limit` option in README.md and configuration docs
+* Updated JSON schema with validation for parallelLimit setting
+* Improved README.md Markdown compatibility for better NuGet.org rendering
+
+**Other Improvements:**
+
+* Increased PR validation timeout from 10 to 20 minutes to accommodate integration tests on Windows
+
+Fixes #456
+
 #### 1.2.0-beta.1 December 15 2025 ####
 
 **BETA RELEASE - Dual-Targeting .NET 8.0 and .NET 10.0 with .slnx Support**

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,40 +2,41 @@
   <PropertyGroup>
     <Copyright>Copyright © 2015-$([System.DateTime]::Now.Year) Petabridge</Copyright>
     <Authors>Petabridge</Authors>
-    <VersionPrefix>1.2.0-beta.1</VersionPrefix>
-    <PackageReleaseNotes>**BETA RELEASE - Dual-Target .NET 8.0/.NET 10.0 with .slnx Support**
+    <VersionPrefix>1.2.0</VersionPrefix>
+    <PackageReleaseNotes>**Stable Release - Parallel Execution Control**
 
-This is a beta release with dual-targeting support for .NET 8.0 and .NET 10.0, and adds support for the new XML-based .slnx solution format on .NET 9.0+.
+This stable release adds a new feature to control parallelism during build and test operations.
 
-**Major Changes:**
+**New Features:**
 
-* **Dual-Targeting .NET 8.0 and .NET 10.0:**
-  The library and CLI tool now target both .NET 8.0 and .NET 10.0 to support a wider range of environments.
+* **Parallel Limit Control:**
+  Added `--parallel-limit` CLI option and `parallelLimit` configuration setting to limit the degree of parallelism when running tasks in parallel. This helps prevent memory exhaustion and random errors when many projects are affected in large solutions.
 
-* **Added .slnx Solution Format Support (.NET 9.0+ only):**
-  Full support for the new XML-based .slnx solution format in both Workspace and Static Graph build engines.
-  Note: .slnx support requires MSBuild 17.12.6+ and Roslyn 5.0.0+, which are only available on .NET 9.0+.
-  The .NET 8.0 build does not support .slnx files.
+  _Example:_
 
-* **TFM-Conditional Dependencies:**
-  - .NET 8.0: MSBuild 17.11.48, Roslyn 4.14.0
-  - .NET 10.0: MSBuild 18.0.2, Roslyn 5.0.0
+  ```shell
+  incrementalist test --parallel --parallel-limit 4
+  ```
 
-* **Improved F# Project Handling:**
-  F# projects now use StaticGraphBuildEngine for better compatibility with Roslyn 5.0+.
+  Or in `incrementalist.json`:
 
-**Important Notes:**
+  ```json
+  {
+    "parallelLimit": 4
+  }
+  ```
 
-* .slnx solution format support is only available when running on .NET 9.0 or later
-* The .NET 8.0 build only supports traditional .sln solution files
+**Documentation:**
 
-**Bug Fixes:**
+* Added comprehensive documentation for `--parallel-limit` option in README.md and configuration docs
+* Updated JSON schema with validation for parallelLimit setting
+* Improved README.md Markdown compatibility for better NuGet.org rendering
 
-* Fixed deprecated Workspace.WorkspaceFailed API usage
-* Fixed multi-targeted project deduplication in StaticGraphBuildEngine
-* Updated F# test samples to use net8.0 target framework
+**Other Improvements:**
 
-Fixes #405</PackageReleaseNotes>
+* Increased PR validation timeout from 10 to 20 minutes to accommodate integration tests on Windows
+
+Fixes #456</PackageReleaseNotes>
     <tags>build, msbuild, incremental build, roslyn, git</tags>
     <PackageIcon>incrementalist-logo-dark.png</PackageIcon>
     <PackageProjectUrl>


### PR DESCRIPTION
This PR prepares the 1.2.0 stable release.

## Changes Since 1.2.0-beta.1

* Added `--parallel-limit` CLI option and `parallelLimit` configuration setting to control parallelism (#457, fixes #456)
* Added comprehensive documentation for the parallel-limit feature
* Updated JSON schema with validation for parallelLimit setting
* Improved README.md Markdown compatibility for NuGet.org rendering
* Increased PR validation timeout to 20 minutes for Windows integration tests

## Release Notes

See RELEASE_NOTES.md for complete details.