### PR TITLE
Use PNG logo in README for proper sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🔄 Incrementalist
 
-![Incrementalist Logo](https://raw.githubusercontent.com/petabridge/Incrementalist/refs/heads/dev/docs/incrementalist-logo-dark.svg)
+![Incrementalist Logo](https://raw.githubusercontent.com/petabridge/Incrementalist/refs/heads/dev/docs/incrementalist-logo-dark.png)
 
 Incrementalist is a .NET tool that leverages [libgit2sharp](https://github.com/libgit2/libgit2sharp/)
 and [Roslyn](https://docs.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) to compute incremental build steps for large


### PR DESCRIPTION
## Summary
Switch README logo from SVG to PNG format.

The SVG was rendering at its full native size without the width constraint we had when using HTML `<img>` tags. PNG has fixed dimensions that display correctly in both GitHub and NuGet.

## Test plan
- [x] Verify logo displays at reasonable size on GitHub