### PR TITLE
fix: bump Microsoft.NET.Test.Sdk to 18.6.0 and fix CVEs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -52,7 +52,7 @@ Fixes #456</PackageReleaseNotes>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.9.3</XunitVersion>
     <TestSdkVersion>18.6.0</TestSdkVersion>
-    <NugetVersion>6.14.0</NugetVersion>
+    <NugetVersion>6.14.3</NugetVersion>
   </PropertyGroup>
   <!-- .NET 8.0 versions (no .slnx support - MSBuild 17.12.6+ requires .NET 9.0+) -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -51,7 +51,7 @@ Fixes #456</PackageReleaseNotes>
   <PropertyGroup>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.9.3</XunitVersion>
-    <TestSdkVersion>18.3.0</TestSdkVersion>
+    <TestSdkVersion>18.6.0</TestSdkVersion>
     <NugetVersion>6.14.0</NugetVersion>
   </PropertyGroup>
   <!-- .NET 8.0 versions (no .slnx support - MSBuild 17.12.6+ requires .NET 9.0+) -->

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,6 +19,8 @@
         <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
         <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
         <PackageVersion Include="NuGet.ProjectModel" Version="$(NugetVersion)" />
+        <!-- CVE-2026-26171 / CVE-2026-33116: patched via 10.0.6, harmless for net10.0 (already ships this) -->
+        <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     </ItemGroup>
     <!-- Test Packages -->
     <ItemGroup>

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -20,6 +20,8 @@
         <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
         <PackageReference Include="NuGet.ProjectModel"/>
+        <!-- CVE-2026-26171 / CVE-2026-33116: patched version for .NET 8.0 runtime -->
+        <PackageReference Include="System.Security.Cryptography.Xml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Incrementalist.Tests/Incrementalist.Tests.csproj
+++ b/src/Incrementalist.Tests/Incrementalist.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
@@ -10,6 +10,8 @@
         <PackageReference Include="Microsoft.VisualStudio.SolutionPersistence" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
+        <!-- CVE-2026-26171 / CVE-2026-33116: patched version for .NET 8.0 runtime -->
+        <PackageReference Include="System.Security.Cryptography.Xml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Incrementalist/Incrementalist.csproj
+++ b/src/Incrementalist/Incrementalist.csproj
@@ -8,6 +8,8 @@
         <PackageReference Include="Libgit2Sharp"/>
         <PackageReference Include="Microsoft.CodeAnalysis.Common"/>
         <PackageReference Include="Microsoft.Extensions.Logging"/>
+        <!-- CVE-2026-26171 / CVE-2026-33116: patched version for .NET 8.0 runtime -->
+        <PackageReference Include="System.Security.Cryptography.Xml" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Changes

- Bump Microsoft.NET.Test.Sdk from 18.3.0 to 18.6.0
- Bump NuGet.Protocol/Packaging from 6.14.0 to 6.14.3  
- Add explicit reference to System.Security.Cryptography.Xml 10.0.6 to resolve CVE-2026-26171 and CVE-2026-33116

Closes #514