### PR TITLE
fix: MSBuild assembly type mismatch on .NET 10.x + bump packages + fix CVEs (#513)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -62,8 +62,9 @@ Fixes #456</PackageReleaseNotes>
   <!-- .NET 9.0+ versions (with .slnx support) -->
   <!-- .slnx support added in MSBuild 17.12.6: https://github.com/dotnet/msbuild/pull/10794 -->
   <!-- .slnx support added in Roslyn 5.0.0-2.final: https://www.nuget.org/packages/Microsoft.CodeAnalysis.Workspaces.MSBuild/5.0.0-2.final -->
+  <!-- MSBuild 18.6.3 matches .NET SDK 10.0.300 / MSBuild shipped with .NET 10 feature band 3 -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'net8.0'">
-    <MicrosoftBuildVersion>18.0.2</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>18.6.3</MicrosoftBuildVersion>
     <RoslynVersion>5.0.0</RoslynVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -51,8 +51,8 @@ Fixes #456</PackageReleaseNotes>
   <PropertyGroup>
     <NBenchVersion>1.2.2</NBenchVersion>
     <XunitVersion>2.9.3</XunitVersion>
-    <TestSdkVersion>18.3.0</TestSdkVersion>
-    <NugetVersion>6.14.0</NugetVersion>
+    <TestSdkVersion>18.6.0</TestSdkVersion>
+    <NugetVersion>6.14.3</NugetVersion>
   </PropertyGroup>
   <!-- .NET 8.0 versions (no .slnx support - MSBuild 17.12.6+ requires .NET 9.0+) -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -19,6 +19,8 @@
         <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
         <PackageVersion Include="Microsoft.VisualStudio.SolutionPersistence" Version="1.0.52" />
         <PackageVersion Include="NuGet.ProjectModel" Version="$(NugetVersion)" />
+        <!-- CVE-2026-26171 / CVE-2026-33116: force patched version for .NET 8.0 consumers -->
+        <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     </ItemGroup>
     <!-- Test Packages -->
     <ItemGroup>

--- a/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
+++ b/src/Incrementalist.Cmd/Incrementalist.Cmd.csproj
@@ -20,6 +20,7 @@
         <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing"/>
         <PackageReference Include="Microsoft.Extensions.Logging.Console"/>
         <PackageReference Include="NuGet.ProjectModel"/>
+        <PackageReference Include="System.Security.Cryptography.Xml" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Incrementalist.Cmd/Program.cs
+++ b/src/Incrementalist.Cmd/Program.cs
@@ -34,6 +34,10 @@ namespace Incrementalist.Cmd
         {
             // Required for Microsoft.Build.Graph.ProjectGraph to work.
             // Without this, it would fail with "The SDK 'Microsoft.NET.Sdk' specified could not be found."
+            // AllowQueryAllDotnetLocations must be set before RegisterDefaults() so MSBuildLocator
+            // discovers .NET SDK MSBuild installations on SDK 10.x+, not just VS-installed MSBuild.
+            // Without this, it falls back to the old GAC version (v15.1.0.0) causing type load failures.
+            MSBuildLocator.AllowQueryAllDotnetLocations = true;
             MSBuildLocator.RegisterDefaults();
         }
 

--- a/src/Incrementalist.Tests/ModuleInitializer.cs
+++ b/src/Incrementalist.Tests/ModuleInitializer.cs
@@ -16,6 +16,8 @@ public class ModuleInitializer
     {
         // Called in Incrementalist.Cmd in the static constructor of the Program class
         // Must also be called for the tests
+        // AllowQueryAllDotnetLocations must be set before RegisterDefaults() — see Program.cs
+        MSBuildLocator.AllowQueryAllDotnetLocations = true;
         MSBuildLocator.RegisterDefaults();
     }
 }


### PR DESCRIPTION
## Problem

Running \`dotnet incrementalist\` on .NET SDK 10.0.x / MSBuild 18.x fails with:

\`\`\`
Could not load type 'Microsoft.Build.Shared.FileSystem.FileSystems'
from assembly 'Microsoft.Build.Framework, Version=15.1.0.0'
\`\`\`

## Root Cause (two-part)

**Part 1 – MSBuildLocator not finding .NET SDK installations**

\`MSBuildLocator.RegisterDefaults()\` without \`AllowQueryAllDotnetLocations = true\` fails to discover the .NET SDK's MSBuild on SDK 10.x+. This was fixed in Program.cs but missed in \`ModuleInitializer.cs\` in the test project, so tests still failed.

**Part 2 – MSBuild NuGet package version mismatch (the real test failure)**

CI agents run SDK 10.0.300 (MSBuild 18.6.3) while the project pinned \`MicrosoftBuildVersion = 18.0.2\`. The SDK's \`Microsoft.Common.CurrentVersion.targets\` calls internal MSBuild types (\`FileSystem.FileSystems\`, \`VersionUtilities\`) added between 18.0.2 and 18.6.3.

Critically, **MSBuildLocator cannot fix this**: the \`Microsoft.Build.Framework.dll\` from the NuGet output directory is loaded by the CLR **before** \`[ModuleInitializer]\` can install the AssemblyResolve handler. Once loaded, an assembly cannot be unloaded or swapped. So the old (18.0.2) assembly stays in memory and the SDK's targets fail when they need the newer types.

Local builds passed because the local machine has SDK 10.0.103 installed (matching the \`global.json\` rollForward logic), and 10.0.103 ships MSBuild 18.0.11 which is compatible with the 18.0.2 NuGet packages. CI agents only have 10.0.300, which is selected by the major rollForward.

## Fix (3 changes)

1. **\`MicrosoftBuildVersion\` bumped from 18.0.2 → 18.6.3** for net10.0+ — ensures the already-loaded NuGet assemblies have all the types SDK 10.0.300 needs
2. **\`MSBuildLocator.AllowQueryAllDotnetLocations = true\`** before \`RegisterDefaults()\` in both \`Program.cs\` and \`ModuleInitializer.cs\` — ensures proper SDK discovery on .NET 10.x
3. **Package bumps + CVE fixes** from PR #517: Test.Sdk 18.6.0, NuGet 6.14.3, System.Security.Cryptography.Xml 10.0.6

## Verification

All 275 tests pass locally (net8.0 + net10.0, 0 warnings, 0 errors).

Fixes #513, closes #514